### PR TITLE
feat: Config resolution & distribution (#37)

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -19,6 +19,15 @@ import { ConfigSchema } from './schema';
 // Re-export merge types
 export type { ConfigLayer, ConfigSource, MergedConfigResult } from './merge';
 export { buildCliOverrides } from './merge';
+export type { ToolPermissionMap } from './resolve';
+// Re-export resolve functions
+export {
+  deriveSubagentConfig,
+  extractAgentConfig,
+  extractCompactionConfig,
+  extractSafetyConfig,
+  resolvePermissions,
+} from './resolve';
 // Re-export schema types
 export type {
   AutonomyLevel,

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -1,0 +1,189 @@
+/**
+ * Config resolution and distribution.
+ *
+ * Bridges the gap between the merged config and the consumers
+ * (agent, safety, tools, TUI). Extracts typed sub-configs from
+ * ResolvedConfig for each layer.
+ */
+
+import type { CompactionConfig } from '../agent/compaction';
+import type { SafetyConfig } from '../agent/safety/types';
+import type { AgentConfig } from '../agent/types';
+import type { PermissionValue, ResolvedConfig } from './schema';
+
+// === Autonomy → Permission mapping ===
+
+/** Per-tool permission map derived from autonomy level */
+export type ToolPermissionMap = Record<string, PermissionValue>;
+
+/**
+ * Autonomy level → baseline per-tool permission mapping.
+ *
+ * This replaces the risk-based shouldConfirm() approach.
+ * Each autonomy level defines which tools auto-approve, prompt, or deny.
+ */
+const AUTONOMY_BASELINES: Record<string, ToolPermissionMap> = {
+  paranoid: {
+    read_file: 'ask',
+    list_dir: 'ask',
+    glob: 'ask',
+    grep: 'ask',
+    write_file: 'ask',
+    edit_file: 'ask',
+    run_command: 'ask',
+    task: 'ask',
+    todo_read: 'ask',
+    todo_write: 'ask',
+  },
+  cautious: {
+    read_file: 'allow',
+    list_dir: 'allow',
+    glob: 'allow',
+    grep: 'allow',
+    write_file: 'ask',
+    edit_file: 'ask',
+    run_command: 'ask',
+    task: 'allow',
+    todo_read: 'allow',
+    todo_write: 'allow',
+  },
+  balanced: {
+    read_file: 'allow',
+    list_dir: 'allow',
+    glob: 'allow',
+    grep: 'allow',
+    write_file: 'allow',
+    edit_file: 'ask',
+    run_command: 'ask',
+    task: 'allow',
+    todo_read: 'allow',
+    todo_write: 'allow',
+  },
+  autonomous: {
+    read_file: 'allow',
+    list_dir: 'allow',
+    glob: 'allow',
+    grep: 'allow',
+    write_file: 'allow',
+    edit_file: 'allow',
+    run_command: 'allow',
+    task: 'allow',
+    todo_read: 'allow',
+    todo_write: 'allow',
+  },
+};
+
+/**
+ * Resolve the effective per-tool permission map.
+ *
+ * Starts from the autonomy level baseline, then applies
+ * any explicit permission overrides from config.
+ */
+export function resolvePermissions(config: ResolvedConfig): ToolPermissionMap {
+  const baseline =
+    AUTONOMY_BASELINES[config.autonomy] ?? AUTONOMY_BASELINES.cautious;
+  const resolved = { ...baseline };
+
+  // Apply explicit overrides
+  for (const [tool, permission] of Object.entries(config.permissions)) {
+    resolved[tool] = permission;
+  }
+
+  return resolved;
+}
+
+// === Sub-config extractors ===
+
+/**
+ * Extract AgentConfig from resolved config.
+ */
+export function extractAgentConfig(config: ResolvedConfig): AgentConfig {
+  return {
+    maxIterations: config.agent.maxIterations,
+    loopDetection: config.agent.loopDetection,
+    loopThreshold: config.agent.loopThreshold,
+    autoCompaction: config.compaction.auto,
+    compactionThreshold: config.compaction.threshold,
+  };
+}
+
+/**
+ * Extract CompactionConfig from resolved config.
+ */
+export function extractCompactionConfig(
+  config: ResolvedConfig,
+): CompactionConfig {
+  return {
+    threshold: config.compaction.threshold,
+    minPreservedMessages: config.compaction.minPreservedMessages,
+    useLLMSummary: config.compaction.useLLMSummary,
+    maxSummaryTokens: config.compaction.maxSummaryTokens,
+  };
+}
+
+/**
+ * Extract SafetyConfig from resolved config.
+ *
+ * Maps the config schema permission vocabulary ("allow"/"ask"/"deny")
+ * to the internal safety layer vocabulary ("always_allow"/"always_confirm"/"always_deny").
+ * This mapping exists temporarily until #32 refactors the internal vocabulary.
+ */
+export function extractSafetyConfig(
+  config: ResolvedConfig,
+  projectRoot: string,
+): Partial<SafetyConfig> {
+  const permissions = resolvePermissions(config);
+
+  // Map config vocabulary to internal vocabulary (temporary until #32)
+  const permissionToInternal: Record<
+    string,
+    'always_allow' | 'always_confirm' | 'always_deny'
+  > = {
+    allow: 'always_allow',
+    ask: 'always_confirm',
+    deny: 'always_deny',
+  };
+
+  const toolOverrides: SafetyConfig['toolOverrides'] = {};
+  for (const [tool, permission] of Object.entries(permissions)) {
+    toolOverrides[tool] = {
+      autonomy: permissionToInternal[permission],
+    };
+  }
+
+  return {
+    projectRoot,
+    autonomyLevel: config.autonomy,
+    maxFileSizeBytes: config.safety.maxFileSizeBytes,
+    maxToolCallsPerTurn: config.safety.maxToolCallsPerTurn,
+    maxToolCallsPerSession: config.safety.maxToolCallsPerSession,
+    allowNetworkCommands: config.safety.allowNetworkCommands,
+    deniedPaths: config.safety.deniedPaths,
+    deniedCommands: config.safety.deniedCommands,
+    enableAuditLog: config.safety.auditLog,
+    auditLogPath: config.safety.auditLogPath,
+    toolOverrides,
+  };
+}
+
+/**
+ * Derive a modified config for subagents (task tool).
+ *
+ * Subagents may need different iteration limits, temperature, etc.
+ * This creates a new ResolvedConfig with the overrides applied.
+ */
+export function deriveSubagentConfig(
+  baseConfig: ResolvedConfig,
+  overrides: {
+    maxIterations?: number;
+    systemPromptOverride?: string;
+  },
+): ResolvedConfig {
+  return {
+    ...baseConfig,
+    agent: {
+      ...baseConfig.agent,
+      maxIterations: overrides.maxIterations ?? baseConfig.agent.maxIterations,
+    },
+  };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,11 +101,10 @@ program
 
     createRoot(renderer).render(
       <App
-        model={config.model}
+        config={config}
         host={host}
         projectPath={projectPath}
         initialSessionId={initialSessionId}
-        initialTheme={config.tui.theme}
       />,
     );
 

--- a/src/tui/hooks/use-agent-context.ts
+++ b/src/tui/hooks/use-agent-context.ts
@@ -3,21 +3,22 @@
  * Handles sidebar stats, context info notifications, and context manipulation.
  */
 
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { compactMessages, getCompactionLevel } from '../../agent/compaction';
+import type { ResolvedConfig } from '../../config/schema';
 import { fetchModelInfo, getContextStats } from '../../lib/tokenizer';
 import {
-  NOTIFICATION_DURATION_SHORT,
   NOTIFICATION_DURATION_LONG,
+  NOTIFICATION_DURATION_SHORT,
 } from '../constants';
-import type { Message, ContextStats, DisplayMessage } from '../types';
+import type { ContextStats, DisplayMessage, Message } from '../types';
 
 export type UseAgentContextProps = {
   /** Current message history */
   history: Message[];
-  /** Model name */
-  model: string;
-  /** Ollama host URL */
+  /** Resolved config */
+  config: ResolvedConfig;
+  /** Ollama host (may differ from config.host due to OLLAMA_HOST env) */
   host: string;
   /** Setter for history (for compaction and forget) */
   setHistory: React.Dispatch<React.SetStateAction<Message[]>>;
@@ -50,11 +51,12 @@ export type UseAgentContextReturn = {
 
 export function useAgentContext({
   history,
-  model,
+  config,
   host,
   setHistory,
   setDisplayMessages,
 }: UseAgentContextProps): UseAgentContextReturn {
+  const model = config.model;
   const [contextInfo, setContextInfo] = useState<string | null>(null);
   const [contextStats, setContextStats] = useState<ContextStats | null>(null);
   const [showContextStats, setShowContextStats] = useState(false);

--- a/src/tui/hooks/use-agent-submit.ts
+++ b/src/tui/hooks/use-agent-submit.ts
@@ -6,43 +6,47 @@
  * pending → confirming → executing → completed/error/denied/blocked
  */
 
-import { useState, useRef } from 'react';
 import type { ToolCall } from 'ollama';
+import { useRef, useState } from 'react';
 import { runAgent } from '../../agent';
-import type { ToolResult, AgentStep } from '../../agent/types';
+import type { AgentStep, ToolResult } from '../../agent/types';
+import { extractAgentConfig, extractSafetyConfig } from '../../config/resolve';
+import type { ResolvedConfig } from '../../config/schema';
 import {
   addMessage,
-  fromUserInput,
   fromAssistantResponse,
+  fromUserInput,
 } from '../../session';
-import { augmentMessageWithFiles } from '../../utils/file-list';
-import type { ToolPart } from '../../session/types';
 import { getTodos } from '../../session/todo';
+import type { ToolPart } from '../../session/types';
 import { generateDiff } from '../../utils/diff';
+import { augmentMessageWithFiles } from '../../utils/file-list';
 import {
   TOOL_ID_RADIX,
-  TOOL_ID_SLICE_START,
   TOOL_ID_SLICE_END,
+  TOOL_ID_SLICE_START,
 } from '../constants';
-import type { ToolMetadata } from '../types';
 import type {
-  Status,
-  Message,
-  DisplayMessage,
-  ToolDisplayMessage,
-  ToolState,
   AgentMode,
-  Session,
   ConfirmationRequest,
   ConfirmationResponse,
+  DisplayMessage,
+  Message,
+  Session,
+  Status,
   Todo,
+  ToolDisplayMessage,
+  ToolMetadata,
+  ToolState,
 } from '../types';
 
 export type UseAgentSubmitProps = {
-  /** Model name */
-  model: string;
-  /** Ollama host URL */
+  /** Resolved config */
+  config: ResolvedConfig;
+  /** Ollama host (may differ from config.host due to OLLAMA_HOST env) */
   host: string;
+  /** Project path for safety config */
+  projectPath: string;
   /** Function to ensure a session exists and return it */
   ensureSession: () => Promise<Session>;
   /** Current mode */
@@ -86,8 +90,9 @@ function generateToolId(): string {
 }
 
 export function useAgentSubmit({
-  model,
+  config,
   host,
+  projectPath,
   ensureSession,
   mode,
   history,
@@ -95,6 +100,7 @@ export function useAgentSubmit({
   setHistory,
   setSidebarTodos,
 }: UseAgentSubmitProps): UseAgentSubmitReturn {
+  const model = config.model;
   const [status, setStatus] = useState<Status>('idle');
   const [error, setError] = useState('');
   const [streamingContent, setStreamingContent] = useState('');
@@ -181,6 +187,8 @@ export function useAgentSubmit({
       mode: modeRef.current,
       sessionId: session.id,
       signal: abortControllerRef.current.signal,
+      config: extractAgentConfig(config),
+      safetyConfig: extractSafetyConfig(config, projectPath),
       onReasoningToken: (token) => setStreamingContent((prev) => prev + token),
       onToolCall: (call: ToolCall, index: number) => {
         const toolId = generateToolId();

--- a/src/tui/hooks/use-session.ts
+++ b/src/tui/hooks/use-session.ts
@@ -5,6 +5,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { DEFAULT_MODE } from '../../agent/modes';
+import type { ResolvedConfig } from '../../config/schema';
 import {
   createSession,
   getMessages,
@@ -27,9 +28,9 @@ import type {
 export type UseSessionProps = {
   /** Project path for session creation */
   projectPath: string;
-  /** Model name */
-  model: string;
-  /** Ollama host URL */
+  /** Resolved config */
+  config: ResolvedConfig;
+  /** Ollama host (may differ from config.host due to OLLAMA_HOST env) */
   host: string;
   /** Initial session ID to load */
   initialSessionId?: string;
@@ -88,11 +89,12 @@ export type UseSessionReturn = {
 
 export function useSession({
   projectPath,
-  model,
+  config,
   host,
   initialSessionId,
   textareaRef,
 }: UseSessionProps): UseSessionReturn {
+  const model = config.model;
   const [currentSession, setCurrentSession] = useState<Session | null>(null);
   const [history, setHistory] = useState<Message[]>([]);
   const [displayMessages, setDisplayMessages] = useState<DisplayMessage[]>([]);

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -3,37 +3,37 @@
  * Main application component with all hooks and UI rendering.
  */
 
-import { useRef, useState } from 'react';
 import type { TextareaRenderable } from '@opentui/core';
 import { RGBA } from '@opentui/core';
+import { useRef, useState } from 'react';
 import { ThemeProvider, useTheme } from '../design';
 import { listSessions } from '../session';
-import { SESSION_LIST_LIMIT } from './constants';
 import {
-  useAgentSubmit,
-  useAgentContext,
-  useSession,
-  useCommandMenu,
-  useKeyboardShortcuts,
-  useFilePicker,
-} from './hooks';
-import {
-  ContextStatsModal,
-  KeyboardShortcutsModal,
-  SessionPicker,
-  ThemePicker,
-  ContextInfoNotification,
+  AssistantMessage,
   CommandMenu,
+  ContextInfoNotification,
+  ContextStatsModal,
   FilePicker,
   InputBox,
+  KeyboardShortcutsModal,
+  SessionPicker,
   SidePanel,
-  UserMessage,
-  AssistantMessage,
-  ToolMessage,
+  ThemePicker,
   ToastNotification,
+  ToolMessage,
+  UserMessage,
 } from './components';
-import { fastScrollAccel } from './utils';
+import { SESSION_LIST_LIMIT } from './constants';
+import {
+  useAgentContext,
+  useAgentSubmit,
+  useCommandMenu,
+  useFilePicker,
+  useKeyboardShortcuts,
+  useSession,
+} from './hooks';
 import type { AppProps, Status } from './types';
+import { fastScrollAccel } from './utils';
 
 /** Prompt template for /init command - creates/updates AGENTS.md */
 const INIT_PROMPT_TEMPLATE = `Please analyze this codebase and create an AGENTS.md file containing:
@@ -45,17 +45,11 @@ If there are Cursor rules (in .cursor/rules/ or .cursorrules) or Copilot rules (
 
 If there's already an AGENTS.md, improve it.`;
 
-export function App({
-  initialTheme,
-  model,
-  host,
-  projectPath,
-  initialSessionId,
-}: AppProps) {
+export function App({ config, host, projectPath, initialSessionId }: AppProps) {
   return (
-    <ThemeProvider initialTheme={initialTheme}>
+    <ThemeProvider initialTheme={config.tui.theme}>
       <AppContent
-        model={model}
+        config={config}
         host={host}
         projectPath={projectPath}
         initialSessionId={initialSessionId}
@@ -64,12 +58,8 @@ export function App({
   );
 }
 
-function AppContent({
-  model,
-  host,
-  projectPath,
-  initialSessionId,
-}: Omit<AppProps, 'initialTheme'>) {
+function AppContent({ config, host, projectPath, initialSessionId }: AppProps) {
+  const model = config.model;
   const { tokens } = useTheme();
   const textareaRef = useRef<TextareaRenderable>(null);
   const statusRef = useRef<Status>('idle');
@@ -78,7 +68,7 @@ function AppContent({
   // Initialize session hook first as other hooks depend on it
   const session = useSession({
     projectPath,
-    model,
+    config,
     host,
     initialSessionId,
     textareaRef,
@@ -87,7 +77,7 @@ function AppContent({
   // Context hook for stats, compaction, and related operations
   const context = useAgentContext({
     history: session.history,
-    model,
+    config,
     host,
     setHistory: session.setHistory,
     setDisplayMessages: session.setDisplayMessages,
@@ -95,8 +85,9 @@ function AppContent({
 
   // Agent submission hook (includes confirmation handling)
   const agent = useAgentSubmit({
-    model,
+    config,
     host,
+    projectPath,
     ensureSession: session.ensureSession,
     mode: session.mode,
     history: session.history,

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -6,10 +6,11 @@ import type { TextareaRenderable } from '@opentui/core';
 import type { Message } from 'ollama';
 import type { AgentMode } from '../agent/modes';
 import type {
+  ConfirmationPreview,
   ConfirmationRequest,
   ConfirmationResponse,
-  ConfirmationPreview,
 } from '../agent/safety/types';
+import type { ResolvedConfig } from '../config/schema';
 import type { ContextStats } from '../lib/tokenizer';
 import type { Session } from '../session';
 import type { Todo } from '../session/todo';
@@ -80,11 +81,10 @@ export type DisplayMessage =
  * Props for the main App component.
  */
 export type AppProps = {
-  model: string;
+  config: ResolvedConfig;
   host: string;
   projectPath: string;
   initialSessionId?: string;
-  initialTheme?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

Closes #37 — Bridges config loading and config consumption.

Previously, the merged ResolvedConfig was computed in index.tsx but only model, host, and tui.theme survived into the app. Agent, safety, compaction, and tool settings were all hardcoded defaults.

### What changed

**New file: src/config/resolve.ts**
- resolvePermissions() — maps autonomy level to per-tool permission map, applies overrides
- extractAgentConfig() — extracts AgentConfig from ResolvedConfig
- extractCompactionConfig() — extracts CompactionConfig from ResolvedConfig
- extractSafetyConfig() — extracts SafetyConfig with permission vocabulary mapping
- deriveSubagentConfig() — creates modified config for task tool subagents

**Config threading: index.tsx -> App -> hooks -> runAgent**
- AppProps now accepts full ResolvedConfig instead of individual model/host/initialTheme
- useSession, useAgentContext, useAgentSubmit all receive ResolvedConfig
- useAgentSubmit passes extracted AgentConfig and SafetyConfig to runAgent()
- Previously these were always undefined (hardcoded defaults used)

**Autonomy -> Permission mapping**
- Each autonomy level (paranoid/cautious/balanced/autonomous) defines a baseline per-tool permission map
- Config permissions object overrides specific tools on top of the baseline
- Maps config vocabulary (allow/ask/deny) to internal vocabulary (always_allow/always_confirm/always_deny) — temporary bridge until #32 refactors internals

### Files changed

| File | Change |
|------|--------|
| src/config/resolve.ts | New — resolution and distribution logic |
| src/config/index.ts | Re-export resolve functions |
| src/index.tsx | Pass full config to App |
| src/tui/types.ts | AppProps accepts ResolvedConfig |
| src/tui/index.tsx | Thread config through App/AppContent |
| src/tui/hooks/use-session.ts | Accept config instead of model/host |
| src/tui/hooks/use-agent-context.ts | Accept config instead of model/host |
| src/tui/hooks/use-agent-submit.ts | Accept config, pass to runAgent |

### Next

This unblocks #31 + #32 (wire agent/safety settings) which can now be done in parallel.