### PR TITLE
feat: wire instructions config to system prompt builder (#35)

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -20,7 +20,7 @@ import {
 } from './loop-detector';
 import type { AgentMode } from './modes';
 import { DEFAULT_MODE } from './modes';
-import { getSystemPromptForMode } from './prompts';
+import { getDefaultContext, getSystemPromptForMode } from './prompts';
 import {
   type ConfirmationRequest,
   type ConfirmationResponse,
@@ -75,6 +75,9 @@ export type RunAgentArgs = {
   config?: Partial<AgentConfig>;
   safetyConfig: SafetyConfig;
   toolsConfig?: ToolsConfig;
+
+  /** Instruction file paths from config (resolved and loaded into system prompt) */
+  configInstructions?: string[];
 
   /** Chat temperature (default 0.2) */
   temperature?: number;
@@ -166,7 +169,11 @@ export async function runAgent(
   // Get mode-specific tools and prompt
   const modeTools = getToolsForMode(mode);
   const systemPrompt =
-    args.systemPromptOverride ?? getSystemPromptForMode(mode);
+    args.systemPromptOverride ??
+    getSystemPromptForMode(
+      mode,
+      getDefaultContext(args.safetyConfig.projectRoot, args.configInstructions),
+    );
 
   log(
     'Starting agent with model:',
@@ -330,6 +337,7 @@ export async function runAgent(
             host: args.host,
             safetyConfig: args.safetyConfig,
             toolsConfig: args.toolsConfig,
+            configInstructions: args.configInstructions,
           },
         },
       );

--- a/src/agent/prompts/shared.ts
+++ b/src/agent/prompts/shared.ts
@@ -4,8 +4,9 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { isAbsolute, join, resolve } from 'node:path';
+import { log } from '../logger';
 
 export type SystemPromptContext = {
   workingDirectory: string;
@@ -15,33 +16,125 @@ export type SystemPromptContext = {
 };
 
 /**
- * Load AGENTS.md from global config and/or project root.
- * Combines both if present (global first, then project-specific).
+ * Resolve an instruction file path relative to a base directory.
  *
- * Locations checked:
- * - Global: ~/.config/ollie/AGENTS.md
- * - Project: <projectRoot>/AGENTS.md
+ * - Paths starting with `~` or `~/` expand to the home directory
+ * - Absolute paths are used as-is
+ * - Relative paths resolve against baseDir
  */
-export function loadProjectInstructions(projectRoot: string): string | null {
+export function resolveInstructionPath(
+  filePath: string,
+  baseDir: string,
+): string {
+  if (filePath.startsWith('~/') || filePath === '~') {
+    return join(homedir(), filePath.slice(2));
+  }
+  if (isAbsolute(filePath)) {
+    return filePath;
+  }
+  return resolve(baseDir, filePath);
+}
+
+/**
+ * Load instruction files from an array of paths.
+ *
+ * Resolves each path relative to baseDir, reads the file,
+ * and returns the content. Missing or unreadable files are
+ * logged as warnings and skipped.
+ *
+ * @param paths - Array of instruction file paths
+ * @param baseDir - Base directory for resolving relative paths
+ * @returns Array of file contents (only successfully read files)
+ */
+export function loadInstructionFiles(
+  paths: string[],
+  baseDir: string,
+): string[] {
+  const contents: string[] = [];
+
+  for (const filePath of paths) {
+    const resolved = resolveInstructionPath(filePath, baseDir);
+    if (!existsSync(resolved)) {
+      log(`Instruction file not found: ${resolved} (from "${filePath}")`);
+      continue;
+    }
+    try {
+      const content = readFileSync(resolved, 'utf-8').trim();
+      if (content) {
+        contents.push(content);
+      }
+    } catch {
+      log(`Could not read instruction file: ${resolved}`);
+    }
+  }
+
+  return contents;
+}
+
+/**
+ * Load project instructions from AGENTS.md files and configured instruction paths.
+ *
+ * Loading order:
+ * 1. Global AGENTS.md (~/.config/ollie/AGENTS.md)
+ * 2. Project AGENTS.md (<projectRoot>/AGENTS.md)
+ * 3. Configured instruction files (from config.instructions)
+ *
+ * Files from config.instructions that duplicate AGENTS.md are
+ * automatically skipped (path-based deduplication).
+ *
+ * @param projectRoot - Project root directory
+ * @param configInstructions - Optional instruction paths from config
+ * @returns Combined instruction content, or null if none found
+ */
+export function loadProjectInstructions(
+  projectRoot: string,
+  configInstructions?: string[],
+): string | null {
   const parts: string[] = [];
+  const loadedPaths = new Set<string>();
 
   // 1. Global AGENTS.md (user-wide instructions)
   const globalPath = join(homedir(), '.config', 'ollie', 'AGENTS.md');
   if (existsSync(globalPath)) {
     try {
       parts.push(readFileSync(globalPath, 'utf-8'));
+      loadedPaths.add(globalPath);
     } catch {
       // Silently skip if unreadable
     }
   }
 
   // 2. Project AGENTS.md (project-specific instructions)
-  const projectPath = join(projectRoot, 'AGENTS.md');
-  if (existsSync(projectPath)) {
+  const projectAgentsPath = join(projectRoot, 'AGENTS.md');
+  if (existsSync(projectAgentsPath)) {
     try {
-      parts.push(readFileSync(projectPath, 'utf-8'));
+      parts.push(readFileSync(projectAgentsPath, 'utf-8'));
+      loadedPaths.add(projectAgentsPath);
     } catch {
       // Silently skip if unreadable
+    }
+  }
+
+  // 3. Configured instruction files (deduplicated against already-loaded paths)
+  if (configInstructions && configInstructions.length > 0) {
+    for (const filePath of configInstructions) {
+      const resolved = resolveInstructionPath(filePath, projectRoot);
+      if (loadedPaths.has(resolved)) {
+        continue; // Already loaded (e.g., AGENTS.md in config.instructions)
+      }
+      if (!existsSync(resolved)) {
+        log(`Instruction file not found: ${resolved} (from "${filePath}")`);
+        continue;
+      }
+      try {
+        const content = readFileSync(resolved, 'utf-8').trim();
+        if (content) {
+          parts.push(content);
+          loadedPaths.add(resolved);
+        }
+      } catch {
+        log(`Could not read instruction file: ${resolved}`);
+      }
     }
   }
 
@@ -49,15 +142,23 @@ export function loadProjectInstructions(projectRoot: string): string | null {
 }
 
 /**
- * Get default context for the current environment
+ * Get default context for the current environment.
+ *
+ * @param projectRoot - Project root (defaults to process.cwd())
+ * @param configInstructions - Optional instruction file paths from config
  */
-export function getDefaultContext(): SystemPromptContext {
-  const workingDirectory = process.cwd();
+export function getDefaultContext(
+  projectRoot?: string,
+  configInstructions?: string[],
+): SystemPromptContext {
+  const workingDirectory = projectRoot ?? process.cwd();
   return {
     workingDirectory,
     platform: process.platform,
     date: new Date().toISOString().split('T')[0] ?? 'unknown',
-    projectInstructions: loadProjectInstructions(workingDirectory) ?? undefined,
+    projectInstructions:
+      loadProjectInstructions(workingDirectory, configInstructions) ??
+      undefined,
   };
 }
 
@@ -73,10 +174,10 @@ Date: ${ctx.date}
 }
 
 /**
- * Project instructions block - included when AGENTS.md exists
+ * Project instructions block - included when instruction files are loaded
  */
 export function buildProjectInstructionsBlock(instructions: string): string {
-  return `# Project Instructions (from AGENTS.md)
+  return `# Project Instructions
 
 ${instructions}`;
 }

--- a/src/agent/tools/task.ts
+++ b/src/agent/tools/task.ts
@@ -110,8 +110,11 @@ The tasks will run concurrently and you'll receive all results together.`,
     const iterationLimits =
       context?.toolsConfig?.task.iterationLimits ?? ITERATION_LIMITS;
 
-    // Build the explore subagent prompt
-    const ctx = getDefaultContext();
+    // Build the explore subagent prompt (with instructions from config)
+    const ctx = getDefaultContext(
+      context?.projectRoot,
+      context?.configInstructions,
+    );
     const systemPromptOverride = buildExplorePrompt(ctx, thoroughness);
 
     // Track files explored by the subagent
@@ -149,6 +152,7 @@ The tasks will run concurrently and you'll receive all results together.`,
 
         safetyConfig: parentSafetyConfig,
         toolsConfig: context?.toolsConfig,
+        configInstructions: context?.configInstructions,
         systemPromptOverride,
       });
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -47,6 +47,8 @@ export type ToolContext = {
   safetyConfig?: SafetyConfig;
   /** Tool-specific configuration from config file */
   toolsConfig?: ToolsConfig;
+  /** Instruction file paths from config (for subagent delegation) */
+  configInstructions?: string[];
 };
 
 /**

--- a/src/tui/hooks/use-agent-submit.ts
+++ b/src/tui/hooks/use-agent-submit.ts
@@ -192,6 +192,7 @@ export function useAgentSubmit({
       config: extractAgentConfig(config),
       safetyConfig: extractSafetyConfig(config, projectPath),
       toolsConfig: extractToolsConfig(config),
+      configInstructions: config.instructions,
       temperature: config.temperature,
       compactionTemperature: config.compaction.temperature,
       onReasoningToken: (token) => setStreamingContent((prev) => prev + token),

--- a/tests/test-config.ts
+++ b/tests/test-config.ts
@@ -4,9 +4,15 @@
  * Run with: bun test tests/test-config.ts
  */
 
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
-
+import {
+  loadInstructionFiles,
+  loadProjectInstructions,
+  resolveInstructionPath,
+} from '../src/agent/prompts/shared';
 import { validatePath } from '../src/agent/safety/path-validation';
 import type { SafetyConfig } from '../src/agent/safety/types';
 import { DEFAULT_SAFETY_CONFIG } from '../src/agent/safety/types';
@@ -594,5 +600,130 @@ describe('extractTuiConfig', () => {
     expect(defaults.toastDuration).toBe(2500); // TOAST_DURATION_MS
     expect(defaults.doubleEscapeThreshold).toBe(500); // DOUBLE_ESCAPE_THRESHOLD_MS
     expect(defaults.sessionListLimit).toBe(50); // SESSION_LIST_LIMIT
+  });
+});
+
+// === Instructions ===
+
+describe('resolveInstructionPath', () => {
+  test('resolves tilde paths to home directory', () => {
+    const result = resolveInstructionPath('~/docs/rules.md', '/project');
+    expect(result).toBe(join(homedir(), 'docs/rules.md'));
+  });
+
+  test('resolves bare tilde to home directory', () => {
+    const result = resolveInstructionPath('~', '/project');
+    expect(result).toBe(homedir());
+  });
+
+  test('preserves absolute paths', () => {
+    const result = resolveInstructionPath('/etc/rules.md', '/project');
+    expect(result).toBe('/etc/rules.md');
+  });
+
+  test('resolves relative paths against base directory', () => {
+    const result = resolveInstructionPath(
+      'docs/CONTRIBUTING.md',
+      '/my/project',
+    );
+    expect(result).toBe('/my/project/docs/CONTRIBUTING.md');
+  });
+
+  test('resolves bare filename against base directory', () => {
+    const result = resolveInstructionPath('AGENTS.md', '/my/project');
+    expect(result).toBe('/my/project/AGENTS.md');
+  });
+});
+
+describe('loadInstructionFiles', () => {
+  const tmpDir = join(import.meta.dir, '.tmp-instructions');
+
+  beforeEach(() => {
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('loads existing files', () => {
+    writeFileSync(join(tmpDir, 'rules.md'), 'Be concise');
+    writeFileSync(join(tmpDir, 'style.md'), 'Use 2 spaces');
+
+    const contents = loadInstructionFiles(['rules.md', 'style.md'], tmpDir);
+    expect(contents).toEqual(['Be concise', 'Use 2 spaces']);
+  });
+
+  test('skips missing files gracefully', () => {
+    writeFileSync(join(tmpDir, 'exists.md'), 'I exist');
+
+    const contents = loadInstructionFiles(['exists.md', 'missing.md'], tmpDir);
+    expect(contents).toEqual(['I exist']);
+  });
+
+  test('skips empty files', () => {
+    writeFileSync(join(tmpDir, 'empty.md'), '   ');
+    writeFileSync(join(tmpDir, 'real.md'), 'Content');
+
+    const contents = loadInstructionFiles(['empty.md', 'real.md'], tmpDir);
+    expect(contents).toEqual(['Content']);
+  });
+
+  test('returns empty array when no files exist', () => {
+    const contents = loadInstructionFiles(['nope.md', 'also-nope.md'], tmpDir);
+    expect(contents).toEqual([]);
+  });
+});
+
+describe('loadProjectInstructions with configInstructions', () => {
+  const tmpDir = join(import.meta.dir, '.tmp-project');
+
+  beforeEach(() => {
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('loads only configured files when no AGENTS.md exists', () => {
+    writeFileSync(join(tmpDir, 'rules.md'), 'Custom rules');
+    const result = loadProjectInstructions(tmpDir, ['rules.md']);
+    expect(result).toBe('Custom rules');
+  });
+
+  test('combines AGENTS.md with configured files', () => {
+    writeFileSync(join(tmpDir, 'AGENTS.md'), 'Agent instructions');
+    writeFileSync(join(tmpDir, 'extra.md'), 'Extra rules');
+    const result = loadProjectInstructions(tmpDir, ['extra.md']);
+    expect(result).toContain('Agent instructions');
+    expect(result).toContain('Extra rules');
+    expect(result).toContain('---'); // separator
+  });
+
+  test('deduplicates AGENTS.md if also in config.instructions', () => {
+    writeFileSync(join(tmpDir, 'AGENTS.md'), 'Agent instructions');
+    // AGENTS.md appears in config.instructions but should only be loaded once
+    const result = loadProjectInstructions(tmpDir, ['AGENTS.md']);
+    // Count occurrences of the content
+    const occurrences = (result ?? '').split('Agent instructions').length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  test('returns null when no files exist and no config instructions', () => {
+    const result = loadProjectInstructions(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  test('returns null when config instructions are empty', () => {
+    const result = loadProjectInstructions(tmpDir, []);
+    expect(result).toBeNull();
+  });
+
+  test('skips missing configured files gracefully', () => {
+    writeFileSync(join(tmpDir, 'AGENTS.md'), 'Agent instructions');
+    const result = loadProjectInstructions(tmpDir, ['nonexistent.md']);
+    // Should still return AGENTS.md content
+    expect(result).toBe('Agent instructions');
   });
 });


### PR DESCRIPTION
## Summary

Connects the existing config.instructions array (already defined in the Zod schema but previously unused) to the system prompt builder. Users can now specify additional instruction files beyond the default AGENTS.md locations.

## Changes

- **src/agent/prompts/shared.ts**: Add resolveInstructionPath() for path resolution (tilde, absolute, relative), extend loadProjectInstructions() to load configured instruction files with path-based deduplication, extend getDefaultContext() to accept projectRoot and configInstructions params
- **src/agent/index.ts**: Add configInstructions to RunAgentArgs, pass through to system prompt context and tool context
- **src/agent/types.ts**: Add configInstructions to ToolContext for subagent propagation
- **src/agent/tools/task.ts**: Forward configInstructions to subagent getDefaultContext and runAgent calls
- **src/tui/hooks/use-agent-submit.ts**: Pass config.instructions into runAgent
- **tests/test-config.ts**: Add 15 tests for path resolution, file loading, deduplication, and edge cases

## How it works

Users can configure additional instruction files in their config:

```jsonc
// In ollie.json (project config)
{
  "instructions": [
    "CONTRIBUTING.md",
    "docs/coding-standards.md",
    "~/global-rules.md"
  ]
}
```

Path resolution: `~` expands to home dir, absolute paths are preserved, relative paths resolve against the project root. Missing files are logged and skipped (no errors). AGENTS.md in config.instructions is deduplicated against the default AGENTS.md loading.

## Testing

- 70 tests pass (55 existing + 15 new)
- Types clean
- Lint clean (only pre-existing clipboard.ts infos)

Closes #35