### PR TITLE
feat(memory): preserve observation history across reflections

### DIFF
--- a/OBSERVATIONAL_MEMORY_V2_PLAN.md
+++ b/OBSERVATIONAL_MEMORY_V2_PLAN.md
@@ -373,10 +373,10 @@ ship, but should be addressed as OM matures in production use.
   aren't fed back into OM tracking. Could be off by 20-30% depending on content type.
   Consider calibrating against actual counts from `onIterationComplete`.
 
-- [ ] **No observation history**: Reflections replace `activeObservations` in-place.
-  `generationCount` increments but previous generations aren't stored. If a reflection
-  loses critical info, it's gone. A simple `observational_memory_history` table would
-  preserve previous generations.
+- [x] **Observation history**: ~~Reflections replace `activeObservations` in-place.~~
+  `updateAfterReflection` now snapshots the current state into
+  `observational_memory_history` before overwriting (migration v8). Previous
+  generations are preserved and queryable via `getOMHistory()`. (#77)
 
 - [ ] **Remove compaction fallback**: `compaction.ts` and related code paths remain in
   the codebase, gated by `memoryConfig.enabled`. Once OM is validated in production,

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -276,6 +276,29 @@ export function updateAfterReflection(
   },
 ): void {
   const db = getDatabase();
+
+  // Snapshot current state into history before overwriting.
+  // Safety net: if a reflection loses critical info, previous
+  // generations are preserved in observational_memory_history.
+  const current = getOMRecord(sessionId);
+  if (current?.activeObservations) {
+    db.run(
+      `INSERT INTO observational_memory_history (
+        id, session_id, generation, active_observations,
+        observation_token_count, origin_type, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        crypto.randomUUID(),
+        sessionId,
+        current.generationCount,
+        current.activeObservations,
+        current.observationTokenCount,
+        current.originType,
+        Date.now(),
+      ],
+    );
+  }
+
   db.run(
     `UPDATE observational_memory SET
       active_observations = ?,
@@ -451,4 +474,52 @@ export function clearBufferedReflection(sessionId: string): void {
 export function deleteOMRecord(sessionId: string): void {
   const db = getDatabase();
   db.run('DELETE FROM observational_memory WHERE session_id = ?', [sessionId]);
+}
+
+// ============================================================================
+// Observation history
+// ============================================================================
+
+export type OMHistoryEntry = {
+  id: string;
+  sessionId: string;
+  generation: number;
+  activeObservations: string;
+  observationTokenCount: number;
+  originType: string;
+  createdAt: number;
+};
+
+type OMHistoryRow = {
+  id: string;
+  session_id: string;
+  generation: number;
+  active_observations: string;
+  observation_token_count: number;
+  origin_type: string;
+  created_at: number;
+};
+
+/**
+ * Get observation history for a session, ordered by generation descending
+ * (most recent first). Returns all previous generations preserved before
+ * reflection overwrites.
+ */
+export function getOMHistory(sessionId: string): OMHistoryEntry[] {
+  const db = getDatabase();
+  const rows = db
+    .query(
+      'SELECT * FROM observational_memory_history WHERE session_id = ? ORDER BY generation DESC',
+    )
+    .all(sessionId) as OMHistoryRow[];
+
+  return rows.map((row) => ({
+    id: row.id,
+    sessionId: row.session_id,
+    generation: row.generation,
+    activeObservations: row.active_observations,
+    observationTokenCount: row.observation_token_count,
+    originType: row.origin_type,
+    createdAt: row.created_at,
+  }));
 }

--- a/src/session/migrations.ts
+++ b/src/session/migrations.ts
@@ -216,6 +216,30 @@ const MIGRATIONS: Migration[] = [
         WHERE observed_message_ids != '[]';
     `,
   },
+  {
+    version: 8,
+    name: 'add_observational_memory_history',
+    sql: `
+      -- Observation history: preserves previous observation generations
+      -- before they are overwritten by reflection. Safety net in case a
+      -- Reflector compression loses critical information.
+      CREATE TABLE IF NOT EXISTS observational_memory_history (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        generation INTEGER NOT NULL,
+        active_observations TEXT NOT NULL,
+        observation_token_count INTEGER NOT NULL,
+        origin_type TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_om_history_session
+        ON observational_memory_history(session_id);
+      CREATE INDEX IF NOT EXISTS idx_om_history_generation
+        ON observational_memory_history(session_id, generation DESC);
+    `,
+  },
 ];
 
 /**

--- a/tests/test-om.ts
+++ b/tests/test-om.ts
@@ -65,6 +65,7 @@ import {
 import {
   clearBufferedReflection,
   deleteOMRecord,
+  getOMHistory,
   getOMRecord,
   getOrCreateOMRecord,
   setBufferingReflectionFlag,
@@ -383,6 +384,11 @@ function createTestSession(sessionId: string): void {
       now,
     ],
   );
+}
+
+/** Delete a session row (cascades to OM records and history) */
+function deleteTestSession(sessionId: string): void {
+  testDb.run('DELETE FROM sessions WHERE id = ?', [sessionId]);
 }
 
 describe('OM store', () => {
@@ -1063,6 +1069,135 @@ describe('Reflector store operations', () => {
       beforeReflection?.lastObservedAt ?? null,
     );
     expect(afterReflection?.totalTokensObserved).toBe(5000);
+  });
+});
+
+// ============================================================================
+// Observation history
+// ============================================================================
+
+describe('observation history', () => {
+  const sessionId = 'om-history-test';
+
+  test('reflection creates a history snapshot of the pre-reflection state', () => {
+    createTestSession(sessionId);
+    getOrCreateOMRecord(sessionId);
+
+    // Simulate an observation
+    updateAfterObservation(sessionId, {
+      activeObservations: '* HIGH (14:00) User wants feature X',
+      observationTokenCount: 100,
+      lastObservedAt: Date.now(),
+      observedUpTo: 3,
+      pendingMessageTokens: 0,
+      totalTokensObserved: 1000,
+      currentTask: 'Build feature X',
+      suggestedResponse: null,
+    });
+
+    // Reflect — should snapshot the observation state first
+    updateAfterReflection(sessionId, {
+      activeObservations: '* HIGH Condensed: feature X in progress',
+      observationTokenCount: 50,
+      currentTask: 'Continue feature X',
+      suggestedResponse: null,
+    });
+
+    const history = getOMHistory(sessionId);
+    expect(history.length).toBe(1);
+    expect(history[0]!.generation).toBe(0);
+    expect(history[0]!.activeObservations).toBe(
+      '* HIGH (14:00) User wants feature X',
+    );
+    expect(history[0]!.observationTokenCount).toBe(100);
+    expect(history[0]!.originType).toBe('observation');
+  });
+
+  test('multiple reflections create multiple history entries', () => {
+    createTestSession(sessionId);
+    getOrCreateOMRecord(sessionId);
+
+    // Gen 0 → observation
+    updateAfterObservation(sessionId, {
+      activeObservations: 'gen 0 observations',
+      observationTokenCount: 200,
+      lastObservedAt: Date.now(),
+      observedUpTo: 5,
+      pendingMessageTokens: 0,
+      totalTokensObserved: 2000,
+      currentTask: null,
+      suggestedResponse: null,
+    });
+
+    // Reflect: gen 0 → gen 1
+    updateAfterReflection(sessionId, {
+      activeObservations: 'gen 1 condensed',
+      observationTokenCount: 100,
+      currentTask: null,
+      suggestedResponse: null,
+    });
+
+    // Reflect: gen 1 → gen 2
+    updateAfterReflection(sessionId, {
+      activeObservations: 'gen 2 condensed',
+      observationTokenCount: 60,
+      currentTask: null,
+      suggestedResponse: null,
+    });
+
+    const history = getOMHistory(sessionId);
+    expect(history.length).toBe(2);
+    // Most recent first (generation DESC)
+    expect(history[0]!.generation).toBe(1);
+    expect(history[0]!.activeObservations).toBe('gen 1 condensed');
+    expect(history[1]!.generation).toBe(0);
+    expect(history[1]!.activeObservations).toBe('gen 0 observations');
+  });
+
+  test('no history entry when record has no observations', () => {
+    createTestSession(sessionId);
+    getOrCreateOMRecord(sessionId);
+
+    // Reflect on empty record — should not create a history entry
+    updateAfterReflection(sessionId, {
+      activeObservations: 'from nothing',
+      observationTokenCount: 10,
+      currentTask: null,
+      suggestedResponse: null,
+    });
+
+    const history = getOMHistory(sessionId);
+    expect(history.length).toBe(0);
+  });
+
+  test('cascade delete cleans up history', () => {
+    createTestSession(sessionId);
+    getOrCreateOMRecord(sessionId);
+
+    updateAfterObservation(sessionId, {
+      activeObservations: 'will be deleted',
+      observationTokenCount: 50,
+      lastObservedAt: Date.now(),
+      observedUpTo: 1,
+      pendingMessageTokens: 0,
+      totalTokensObserved: 500,
+      currentTask: null,
+      suggestedResponse: null,
+    });
+
+    updateAfterReflection(sessionId, {
+      activeObservations: 'condensed',
+      observationTokenCount: 20,
+      currentTask: null,
+      suggestedResponse: null,
+    });
+
+    expect(getOMHistory(sessionId).length).toBe(1);
+
+    // Delete the session — should cascade to history
+    deleteTestSession(sessionId);
+
+    expect(getOMHistory(sessionId).length).toBe(0);
   });
 });
 


### PR DESCRIPTION
Closes #77

## Summary

Add an `observational_memory_history` table that snapshots the current observation state before each reflection overwrites it. Safety net for Reflector compression that may lose critical information.

## Changes

- **Migration v8**: `observational_memory_history` table with session cascade delete
- **`updateAfterReflection`** in `store.ts`: INSERTs current state into history before the UPDATE overwrites it. Skips snapshot if record has no observations (empty initial state).
- **`getOMHistory()`**: Query function returning previous generations ordered by generation DESC
- **4 new tests**: snapshot creation, multiple generations, empty guard, cascade delete
- **Plan doc**: Item 3 in Known Limitations marked resolved

## Verification

- 140 tests pass (136 existing + 4 new), 0 failures
- Type check clean (only pre-existing playground errors)
- Lint clean (only pre-existing warnings)