### PR TITLE
feat(memory): add memory.host config for separate Observer/Reflector host

### DIFF
--- a/.changeset/memory-host-config.md
+++ b/.changeset/memory-host-config.md
@@ -1,0 +1,5 @@
+---
+"olliecode": patch
+---
+
+Add optional `memory.host` config to use a separate Ollama host for Observer/Reflector calls. Enables using a local model for memory while the main model runs on Ollama Cloud.

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -201,6 +201,7 @@ export function extractTuiConfig(config: ResolvedConfig): TuiConfig {
 export function extractMemoryConfig(config: ResolvedConfig): MemoryConfig {
   return {
     enabled: config.memory.enabled,
+    host: config.memory.host,
     model: config.memory.model,
     observation: {
       messageTokens: config.memory.observation.messageTokens,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -163,6 +163,7 @@ const MemoryReflectionObjectSchema = z.object({
 
 const MemoryObjectSchema = z.object({
   enabled: z.boolean().default(true),
+  host: z.string().url().optional(),
   model: z.string().optional(),
   observation: MemoryObservationObjectSchema.default(() =>
     MemoryObservationObjectSchema.parse({}),

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -233,6 +233,8 @@ export type ReflectionConfig = {
 export type MemoryConfig = {
   /** Enable observational memory (default: true) */
   enabled: boolean;
+  /** Ollama host for Observer/Reflector (default: same as main host) */
+  host?: string;
   /** Model for Observer/Reflector (default: same as main agent model) */
   model?: string;
   /** Observation settings */

--- a/src/tui/hooks/use-agent-submit.ts
+++ b/src/tui/hooks/use-agent-submit.ts
@@ -210,7 +210,7 @@ export function useAgentSubmit(
           session.id,
           store.history(),
           memoryConfig.model ?? model,
-          host,
+          memoryConfig.host ?? host,
           memoryConfig,
         );
         omObservationBlock = omResult.observationBlock ?? undefined;
@@ -253,7 +253,7 @@ export function useAgentSubmit(
             session.id,
             msgs,
             memoryConfig.model ?? model,
-            host,
+            memoryConfig.host ?? host,
             memoryConfig,
           );
         }


### PR DESCRIPTION
Closes #84

## Problem

Observer/Reflector LLM calls always used the main `host`, so the memory model had to exist on the same Ollama instance. This prevented using a local model for memory while the main model ran on Ollama Cloud.

## Fix

Add optional `memory.host` config. When set, OM calls use this host instead of the main host.

```json
{
  "host": "https://ollama.com",
  "model": "glm-5.1:cloud",
  "memory": {
    "host": "http://127.0.0.1:11434",
    "model": "glm-4.7-flash:latest"
  }
}
```

## Changes (6 lines across 4 files)

- `schema.ts`: `host: z.string().url().optional()` in MemoryObjectSchema
- `types.ts`: `host?: string` in MemoryConfig
- `resolve.ts`: pass `host` through extractMemoryConfig
- `use-agent-submit.ts`: `memoryConfig.host ?? host` in processOMStep + checkMidLoopBuffering

## Verification

140 OM tests pass, 0 fail.