### PR TITLE
refactor: keyboard focus/priority system to replace isModalOpen piping

### DIFF
--- a/.changeset/keyboard-focus-stack.md
+++ b/.changeset/keyboard-focus-stack.md
@@ -1,0 +1,5 @@
+---
+"olliecode": minor
+---
+
+Replaced `isModalOpen` prop threading with a keyboard focus stack system. Modals and overlays now automatically claim keyboard focus via `useFocusLayer()`, preventing key leak bugs between layers. Added `useScopedKeyboard()` as a drop-in replacement for `useKeyboard` that respects focus priority.

--- a/src/tui/components/command-menu.tsx
+++ b/src/tui/components/command-menu.tsx
@@ -4,9 +4,9 @@
  */
 
 import type { ScrollBoxRenderable } from '@opentui/core';
-import { useKeyboard } from '@opentui/solid';
 import { createEffect, createMemo, Index, mergeProps, Show } from 'solid-js';
 import { useTheme } from '../../design';
+import { FocusLayer, useFocusLayer, useScopedKeyboard } from '../keyboard';
 import { getScrollChildBounds, scrollIntoView } from '../utils';
 
 export type SlashCommand = {
@@ -60,7 +60,9 @@ export function CommandMenu(rawProps: CommandMenuProps) {
     if (bounds) scrollIntoView(scrollRef, bounds.top, bounds.bottom);
   });
 
-  useKeyboard((key: { name?: string }) => {
+  useFocusLayer(FocusLayer.COMMAND_MENU);
+
+  useScopedKeyboard(FocusLayer.COMMAND_MENU, (key) => {
     const cmds = filteredCommands();
     switch (key.name) {
       case 'up':

--- a/src/tui/components/file-picker.tsx
+++ b/src/tui/components/file-picker.tsx
@@ -5,10 +5,10 @@
  */
 
 import type { ScrollBoxRenderable } from '@opentui/core';
-import { useKeyboard } from '@opentui/solid';
 import type { JSX } from 'solid-js';
 import { createEffect, createMemo, Index, mergeProps, Show } from 'solid-js';
 import { useTheme } from '../../design';
+import { FocusLayer, useFocusLayer, useScopedKeyboard } from '../keyboard';
 import { type FuzzyMatch, fuzzySearch } from '../../lib/fuzzy';
 import { getScrollChildBounds, scrollIntoView } from '../utils';
 
@@ -72,7 +72,9 @@ export function FilePicker(rawProps: FilePickerProps) {
     if (bounds) scrollIntoView(scrollRef, bounds.top, bounds.bottom);
   });
 
-  useKeyboard((key: { name?: string }) => {
+  useFocusLayer(FocusLayer.FILE_PICKER);
+
+  useScopedKeyboard(FocusLayer.FILE_PICKER, (key) => {
     const r = results();
     switch (key.name) {
       case 'up':

--- a/src/tui/components/modal.tsx
+++ b/src/tui/components/modal.tsx
@@ -5,9 +5,10 @@
 
 import type { JSX } from 'solid-js';
 import { createMemo, mergeProps } from 'solid-js';
-import { useKeyboard, useTerminalDimensions } from '@opentui/solid';
+import { useTerminalDimensions } from '@opentui/solid';
 import { RGBA } from '@opentui/core';
 import { useTheme } from '../../design';
+import { FocusLayer, useFocusLayer, useScopedKeyboard } from '../keyboard';
 
 export type ModalProps = {
   title: string;
@@ -21,7 +22,10 @@ export function Modal(rawProps: ModalProps) {
   const { tokens } = useTheme();
   const dimensions = useTerminalDimensions();
 
-  useKeyboard((key: { name?: string }) => {
+  // Push "modal" layer — all children sharing this layer receive keys
+  useFocusLayer(FocusLayer.MODAL);
+
+  useScopedKeyboard(FocusLayer.MODAL, (key) => {
     if (key.name === 'escape' || key.name === 'q') {
       props.onClose();
     }

--- a/src/tui/components/session-picker.tsx
+++ b/src/tui/components/session-picker.tsx
@@ -5,9 +5,10 @@
  */
 
 import type { InputRenderable, ScrollBoxRenderable } from '@opentui/core';
-import { useKeyboard, useTerminalDimensions } from '@opentui/solid';
+import { useTerminalDimensions } from '@opentui/solid';
 import { createEffect, createMemo, createSignal, For, Show } from 'solid-js';
 import { useTheme } from '../../design';
+import { FocusLayer, useScopedKeyboard } from '../keyboard';
 import { deleteSession, type Session, updateSession } from '../../session';
 import { scrollIntoView } from '../utils';
 import { Modal } from './modal';
@@ -220,7 +221,7 @@ export function SessionPicker(props: SessionPickerProps) {
     props.onSessionsChanged();
   };
 
-  useKeyboard((key: { name?: string; ctrl?: boolean }) => {
+  useScopedKeyboard(FocusLayer.MODAL, (key) => {
     if (mode() === 'rename') {
       if (key.name === 'escape') setMode('browse');
       else if (key.name === 'return') handleRenameSubmit();

--- a/src/tui/components/theme-picker.tsx
+++ b/src/tui/components/theme-picker.tsx
@@ -4,9 +4,9 @@
  */
 
 import { Index, createEffect, createSignal } from 'solid-js';
-import { useKeyboard } from '@opentui/solid';
 import { Modal } from './modal';
 import { useTheme, getThemeList } from '../../design';
+import { FocusLayer, useScopedKeyboard } from '../keyboard';
 
 export type ThemePickerProps = {
   onSelect: (themeId: string) => void;
@@ -36,7 +36,7 @@ export function ThemePicker(props: ThemePickerProps) {
     props.onCancel();
   };
 
-  useKeyboard((key: { name?: string }) => {
+  useScopedKeyboard(FocusLayer.MODAL, (key) => {
     switch (key.name) {
       case 'up':
       case 'k':

--- a/src/tui/components/tool-message.tsx
+++ b/src/tui/components/tool-message.tsx
@@ -6,12 +6,12 @@
  * This replaces the old separate tool_call + tool_result + ConfirmationDialog pattern.
  */
 
-import { useKeyboard } from '@opentui/solid';
 import type { JSX } from 'solid-js';
 import { Show } from 'solid-js';
 import type { ConfirmationResponse } from '../../agent/safety/types';
 import { useTheme } from '../../design';
 import type { SemanticTokens } from '../../design/tokens';
+import { FocusLayer, useScopedKeyboard } from '../keyboard';
 import type { ToolDisplayMessage, ToolMetadata, ToolState } from '../types';
 import { DiffView } from './diff-view';
 
@@ -23,8 +23,6 @@ export type ToolMessageProps = {
   isActiveConfirmation?: boolean;
   /** Whether to show expanded output for read-only tools (toggle with Ctrl+E) */
   expanded?: boolean;
-  /** Whether a modal (command menu, session picker) is open — suppresses confirmation keys */
-  isModalOpen?: () => boolean;
 };
 
 /** Read-only tools that support expand/collapse */
@@ -283,15 +281,13 @@ function ConfirmingView(props: {
   message: ToolDisplayMessage;
   onResponse?: (response: ConfirmationResponse) => void;
   isActive?: boolean;
-  isModalOpen?: () => boolean;
   tokens: SemanticTokens;
 }) {
   let responded = false;
 
-  useKeyboard((key: { name?: string }) => {
+  useScopedKeyboard(FocusLayer.APP, (key) => {
     if (props.message.state.status !== 'confirming') return;
     if (!props.isActive || responded || !props.onResponse) return;
-    if (props.isModalOpen?.()) return;
 
     switch (key.name?.toLowerCase()) {
       case 'y':
@@ -639,7 +635,6 @@ export function ToolMessage(props: ToolMessageProps) {
           message={props.message}
           onResponse={props.onConfirmationResponse}
           isActive={props.isActiveConfirmation}
-          isModalOpen={props.isModalOpen}
           tokens={tokens}
         />
       );

--- a/src/tui/hooks/use-command-menu.ts
+++ b/src/tui/hooks/use-command-menu.ts
@@ -3,18 +3,14 @@
  * Manages command filtering, selection, and actions.
  */
 
-import { useKeyboard } from '@opentui/solid';
 import { createSignal, type Setter } from 'solid-js';
 import type { SlashCommand } from '../components/command-menu';
-import type { Status, TextareaRef } from '../types';
+import { FocusLayer, useScopedKeyboard } from '../keyboard';
+import type { TextareaRef } from '../types';
 
 export type UseCommandMenuProps = {
   /** Getter for textarea ref */
   getTextareaRef: () => TextareaRef;
-  /** Current status (signal accessor) */
-  status: () => Status;
-  /** Whether session picker is open (signal accessor) */
-  showSessionPicker: () => boolean;
   /** Handlers from other hooks */
   handlers: {
     handleNewSession: () => void;
@@ -145,25 +141,31 @@ export function useCommandMenu(
     },
   ];
 
-  // Detect / in textarea and show command menu
-  useKeyboard(() => {
-    setTimeout(() => {
-      const ref = props.getTextareaRef();
-      if (!ref || ref.isDestroyed) return;
-      const currentText = ref.plainText ?? '';
-      if (props.status() !== 'thinking' && !props.showSessionPicker()) {
-        if (currentText.startsWith('/')) {
-          const newFilter = currentText.slice(1);
-          if (!showCommandMenu()) setShowCommandMenu(true);
-          setCommandFilter(newFilter);
-        } else if (showCommandMenu()) {
+  // Detect / in textarea and show command menu.
+  // Global because this monitor must keep running while the command-menu
+  // overlay is open (to detect when the user removes the "/" trigger).
+  useScopedKeyboard(
+    FocusLayer.APP,
+    () => {
+      setTimeout(() => {
+        const ref = props.getTextareaRef();
+        if (!ref || ref.isDestroyed) return;
+        const currentText = ref.plainText ?? '';
+        if (!currentText.startsWith('/')) {
+          // No slash — close menu if open
+          if (!showCommandMenu()) return;
           setShowCommandMenu(false);
           setCommandFilter('');
           setCommandSelectedIndex(0);
+          return;
         }
-      }
-    }, 0);
-  });
+
+        if (!showCommandMenu()) setShowCommandMenu(true);
+        setCommandFilter(currentText.slice(1));
+      }, 0);
+    },
+    { global: true },
+  );
 
   const handleCommandSelect = (command: SlashCommand) => {
     setShowCommandMenu(false);

--- a/src/tui/hooks/use-file-picker.ts
+++ b/src/tui/hooks/use-file-picker.ts
@@ -3,18 +3,14 @@
  * Manages file filtering, selection, and path insertion.
  */
 
-import { useKeyboard } from '@opentui/solid';
 import { createSignal, onMount } from 'solid-js';
 import { getFilesAndDirectories } from '../../utils/file-list';
-import type { Status, TextareaRef } from '../types';
+import { FocusLayer, useScopedKeyboard } from '../keyboard';
+import type { TextareaRef } from '../types';
 
 export type UseFilePickerProps = {
   /** Getter for textarea ref */
   getTextareaRef: () => TextareaRef;
-  /** Current status (signal accessor) */
-  status: () => Status;
-  /** Whether other modals are open (signal accessor) */
-  isModalOpen: () => boolean;
 };
 
 export type UseFilePickerReturn = {
@@ -46,20 +42,32 @@ export function useFilePicker(props: UseFilePickerProps): UseFilePickerReturn {
     void getFilesAndDirectories().then(setFiles);
   });
 
-  // Detect @ in textarea and show file picker
-  useKeyboard(() => {
-    setTimeout(() => {
-      const ref = props.getTextareaRef();
-      if (!ref || ref.isDestroyed) return;
-      if (props.status() === 'thinking' || props.isModalOpen()) return;
+  // Detect @ in textarea and show file picker.
+  // Global because this monitor must keep running while the file-picker
+  // overlay is open (to detect when the user removes the "@" trigger).
+  useScopedKeyboard(
+    FocusLayer.APP,
+    () => {
+      setTimeout(() => {
+        const ref = props.getTextareaRef();
+        if (!ref || ref.isDestroyed) return;
 
-      const currentText = ref.plainText ?? '';
+        const currentText = ref.plainText ?? '';
 
-      // Find the last @ that could be triggering the picker
-      // Look for @ that's either at start or preceded by whitespace
-      const lastAtIndex = findLastTriggerAt(currentText);
+        // Find the last @ that could be triggering the picker
+        // Look for @ that's either at start or preceded by whitespace
+        const lastAtIndex = findLastTriggerAt(currentText);
 
-      if (lastAtIndex !== null) {
+        if (lastAtIndex === null) {
+          // No valid @ trigger — close picker if open
+          if (!showFilePicker()) return;
+          setShowFilePicker(false);
+          setFileFilter('');
+          setFileSelectedIndex(0);
+          setAtPosition(null);
+          return;
+        }
+
         // Extract filter: text after @ until cursor/end, stopping at whitespace
         const afterAt = currentText.slice(lastAtIndex + 1);
         const filterEnd = afterAt.search(/\s/);
@@ -70,15 +78,10 @@ export function useFilePicker(props: UseFilePickerProps): UseFilePickerReturn {
           setAtPosition(lastAtIndex);
         }
         setFileFilter(filter);
-      } else if (showFilePicker()) {
-        // No valid @ trigger, close picker
-        setShowFilePicker(false);
-        setFileFilter('');
-        setFileSelectedIndex(0);
-        setAtPosition(null);
-      }
-    }, 0);
-  });
+      }, 0);
+    },
+    { global: true },
+  );
 
   const handleFileSelect = (path: string) => {
     const ref = props.getTextareaRef();

--- a/src/tui/hooks/use-keyboard-shortcuts.ts
+++ b/src/tui/hooks/use-keyboard-shortcuts.ts
@@ -6,13 +6,14 @@
  * In Solid, signal accessors always return current values — no ref-mirror pattern needed.
  */
 
-import { useKeyboard, useRenderer } from '@opentui/solid';
+import { useRenderer } from '@opentui/solid';
 import { createSignal } from 'solid-js';
 import { toggleMode } from '../../agent/modes';
 import type { TuiConfig } from '../../config/resolve';
 import { Clipboard } from '../../lib/clipboard';
 import { updateSession } from '../../session';
 import { DOUBLE_ESCAPE_THRESHOLD_MS } from '../constants';
+import { FocusLayer, useScopedKeyboard } from '../keyboard';
 import type { AgentMode, Session, Status } from '../types';
 
 export type UseKeyboardShortcutsProps = {
@@ -24,10 +25,6 @@ export type UseKeyboardShortcutsProps = {
   setMode: (mode: AgentMode) => void;
   /** Abort function */
   abort: () => void;
-  /** Whether command menu is open (signal accessor) */
-  showCommandMenu: () => boolean;
-  /** Whether session picker is open (signal accessor) */
-  showSessionPicker: () => boolean;
   /** Current session for persisting mode changes (signal accessor) */
   currentSession: () => Session | null;
   /** Callback when copy succeeds (shows toast) */
@@ -55,60 +52,53 @@ export function useKeyboardShortcuts(
   const [toolsExpanded, setToolsExpanded] = createSignal(false);
   const [showHelp, setShowHelp] = createSignal(false);
 
-  // No ref-mirror pattern needed — signal accessors return current values
-  useKeyboard((key: { ctrl?: boolean; name?: string }) => {
-    // Ctrl+P: Toggle keyboard shortcuts help
-    if (key.ctrl && key.name === 'p') {
-      setShowHelp((prev) => !prev);
-      return;
-    }
+  // Global shortcuts — always fire regardless of focus layer
+  useScopedKeyboard(
+    FocusLayer.BASE,
+    (key) => {
+      // Ctrl+P: Toggle keyboard shortcuts help
+      if (key.ctrl && key.name === 'p') {
+        setShowHelp((prev) => !prev);
+        return;
+      }
 
-    // Ctrl+Y: Copy selected text to clipboard
-    if (key.ctrl && key.name === 'y') {
-      const selection = renderer.getSelection();
-      if (selection) {
-        const selectedText = selection.getSelectedText();
+      // Ctrl+Y: Copy selected text to clipboard
+      if (key.ctrl && key.name === 'y') {
+        const selectedText = renderer.getSelection()?.getSelectedText();
         if (selectedText) {
           void Clipboard.copy(selectedText).then(() => {
             props.onCopySuccess('Copied to clipboard');
           });
         }
+        return;
       }
-      return;
-    }
 
-    // Ctrl+K: Toggle debug overlay
-    if (key.ctrl && key.name === 'k') {
-      renderer.toggleDebugOverlay();
-      renderer.console.toggle();
-      return;
-    }
+      // Ctrl+K: Toggle debug overlay
+      if (key.ctrl && key.name === 'k') {
+        renderer.toggleDebugOverlay();
+        renderer.console.toggle();
+      }
+    },
+    { global: true },
+  );
 
-    // Tab: Toggle mode (only when idle and no modals open)
-    if (
-      key.name === 'tab' &&
-      props.status() !== 'thinking' &&
-      !props.showCommandMenu() &&
-      !props.showSessionPicker()
-    ) {
+  // App-layer shortcuts — suppressed when a modal/overlay has focus
+  useScopedKeyboard(FocusLayer.APP, (key) => {
+    // Tab: Toggle mode (only when idle)
+    if (key.name === 'tab' && props.status() !== 'thinking') {
       const newMode = toggleMode(props.mode());
       props.setMode(newMode);
-      const session = props.currentSession();
-      if (session) {
-        updateSession(session.id, { mode: newMode });
-      }
+      const sessionId = props.currentSession()?.id;
+      if (sessionId) updateSession(sessionId, { mode: newMode });
       return;
     }
 
     // Double-Escape: Abort agent (only when thinking)
     if (key.name === 'escape' && props.status() === 'thinking') {
       const now = Date.now();
-      if (now - lastEscape < doubleEscapeThreshold) {
-        props.abort();
-        lastEscape = 0;
-      } else {
-        lastEscape = now;
-      }
+      const isDouble = now - lastEscape < doubleEscapeThreshold;
+      lastEscape = isDouble ? 0 : now;
+      if (isDouble) props.abort();
       return;
     }
 

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -9,6 +9,7 @@ import { createMemo, createSignal, For, Show } from 'solid-js';
 import { extractTuiConfig } from '../config/resolve';
 import { ThemeProvider, useTheme } from '../design';
 import { listSessions } from '../session';
+import { FocusLayer, KeyboardFocusProvider, useFocusLayer } from './keyboard';
 import {
   AssistantMessage,
   CommandMenu,
@@ -52,13 +53,15 @@ If there's already an AGENTS.md, improve it.`;
 export function App(props: AppProps) {
   return (
     <ThemeProvider initialTheme={props.config.tui.theme}>
-      <AppContent
-        config={props.config}
-        configLayers={props.configLayers}
-        configWarnings={props.configWarnings}
-        projectPath={props.projectPath}
-        initialSessionId={props.initialSessionId}
-      />
+      <KeyboardFocusProvider>
+        <AppContent
+          config={props.config}
+          configLayers={props.configLayers}
+          configWarnings={props.configWarnings}
+          projectPath={props.projectPath}
+          initialSessionId={props.initialSessionId}
+        />
+      </KeyboardFocusProvider>
     </ThemeProvider>
   );
 }
@@ -68,6 +71,9 @@ function AppContent(props: AppProps) {
   const configWarnings = props.configWarnings ?? [];
   const model = props.config.model;
   const { tokens } = useTheme();
+
+  // Register the "app" focus layer — active when no modal/overlay is open
+  useFocusLayer(FocusLayer.APP);
   let textareaRef: TextareaRenderable | undefined;
   const [toast, setToast] = createSignal<string | null>(null);
   const [showConfigModal, setShowConfigModal] = createSignal(false);
@@ -124,8 +130,6 @@ function AppContent(props: AppProps) {
   // Command menu hook
   const commands = useCommandMenu({
     getTextareaRef,
-    status: agent.status,
-    showSessionPicker: session.showSessionPicker,
     handlers: {
       handleNewSession: session.handleNewSession,
       handleClearContext: context.handleClearContext,
@@ -142,9 +146,6 @@ function AppContent(props: AppProps) {
   // File picker hook for @ mentions
   const filePicker = useFilePicker({
     getTextareaRef,
-    status: agent.status,
-    isModalOpen: () =>
-      session.showSessionPicker() || commands.showCommandMenu(),
   });
 
   // Global keyboard shortcuts
@@ -153,8 +154,6 @@ function AppContent(props: AppProps) {
     mode: session.mode,
     setMode: session.setMode,
     abort: agent.abort,
-    showCommandMenu: commands.showCommandMenu,
-    showSessionPicker: session.showSessionPicker,
     currentSession: session.currentSession,
     onCopySuccess: (message: string) => setToast(message),
     tuiConfig: tuiConfig(),
@@ -397,10 +396,6 @@ function AppContent(props: AppProps) {
                           agent.handleToolConfirmation(response);
                         }}
                         expanded={toolsExpanded()}
-                        isModalOpen={() =>
-                          session.showSessionPicker() ||
-                          commands.showCommandMenu()
-                        }
                       />
                     </Show>
                     <Show when={msg.type === 'compaction_summary' && msg}>

--- a/src/tui/keyboard/index.ts
+++ b/src/tui/keyboard/index.ts
@@ -1,0 +1,7 @@
+export {
+  FocusLayer,
+  type FocusLayerId,
+  KeyboardFocusProvider,
+  useFocusLayer,
+  useScopedKeyboard,
+} from './keyboard-focus';

--- a/src/tui/keyboard/keyboard-focus.tsx
+++ b/src/tui/keyboard/keyboard-focus.tsx
@@ -1,0 +1,163 @@
+/**
+ * Keyboard focus stack system.
+ *
+ * Replaces the brittle `isModalOpen` prop-threading pattern with a
+ * stack-based focus model.  Only the topmost layer (plus any layers
+ * marked `global`) receive keyboard events.
+ *
+ * Usage:
+ *   <KeyboardFocusProvider>        — wrap the app once
+ *   useFocusLayer("modal")         — push/pop on mount/cleanup
+ *   useScopedKeyboard("modal", h)  — gated useKeyboard
+ *   useScopedKeyboard("base", h, { global: true })  — always fires
+ */
+
+import { useKeyboard } from '@opentui/solid';
+import {
+  createContext,
+  createSignal,
+  onCleanup,
+  useContext,
+  type JSX,
+} from 'solid-js';
+
+// ---------------------------------------------------------------------------
+// Layer IDs
+// ---------------------------------------------------------------------------
+
+/** Well-known focus layer identifiers. */
+export const FocusLayer = {
+  /** Global shortcuts (Ctrl+K, Ctrl+Y, Ctrl+P) — always fires via `{ global: true }`. */
+  BASE: 'base',
+  /** Default app layer — textarea monitors, mode toggle, confirmation Y/N/A. */
+  APP: 'app',
+  /** Full-screen modal (SessionPicker, ThemePicker, ConfigModal, etc.). */
+  MODAL: 'modal',
+  /** Slash command overlay above the textarea. */
+  COMMAND_MENU: 'command-menu',
+  /** @ file-mention overlay above the textarea. */
+  FILE_PICKER: 'file-picker',
+} as const;
+
+export type FocusLayerId = (typeof FocusLayer)[keyof typeof FocusLayer];
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+type KeyboardFocusContextValue = {
+  /** Push a layer onto the focus stack (called on mount). */
+  push: (layerId: string) => void;
+  /** Remove a layer from the focus stack (called on cleanup). */
+  pop: (layerId: string) => void;
+  /** Returns true when `layerId` is the topmost layer. */
+  isActive: (layerId: string) => boolean;
+  /** The current topmost layer id. */
+  activeLayer: () => string | undefined;
+};
+
+const KeyboardFocusContext = createContext<KeyboardFocusContextValue>();
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export function KeyboardFocusProvider(props: { children: JSX.Element }) {
+  const [stack, setStack] = createSignal<string[]>([]);
+
+  const push = (layerId: string) => {
+    setStack((prev) => [...prev, layerId]);
+  };
+
+  const pop = (layerId: string) => {
+    setStack((prev) => {
+      // Remove the *last* occurrence of layerId (in case of duplicates).
+      const idx = prev.lastIndexOf(layerId);
+      if (idx === -1) return prev;
+      const next = [...prev];
+      next.splice(idx, 1);
+      return next;
+    });
+  };
+
+  const activeLayer = () => {
+    const s = stack();
+    return s.length > 0 ? s[s.length - 1] : undefined;
+  };
+
+  const isActive = (layerId: string) => activeLayer() === layerId;
+
+  const ctx: KeyboardFocusContextValue = {
+    push,
+    pop,
+    isActive,
+    activeLayer,
+  };
+
+  return (
+    <KeyboardFocusContext.Provider value={ctx}>
+      {props.children}
+    </KeyboardFocusContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+function useFocusContext(): KeyboardFocusContextValue {
+  const ctx = useContext(KeyboardFocusContext);
+  if (!ctx) {
+    throw new Error(
+      'useFocusLayer / useScopedKeyboard must be used inside <KeyboardFocusProvider>',
+    );
+  }
+  return ctx;
+}
+
+/**
+ * Register a focus layer that auto-pushes on mount and pops on cleanup.
+ * Returns `isActive()` — true when this layer is the topmost.
+ */
+export function useFocusLayer(layerId: FocusLayerId): () => boolean {
+  const ctx = useFocusContext();
+  ctx.push(layerId);
+  onCleanup(() => ctx.pop(layerId));
+  return () => ctx.isActive(layerId);
+}
+
+/**
+ * A scoped version of `useKeyboard` from @opentui/solid.
+ *
+ * The handler only fires when `layerId` is the active (topmost) focus layer,
+ * unless `opts.global` is true — in which case it always fires.
+ *
+ * **Does NOT push/pop a layer.** Pair with `useFocusLayer` in components
+ * that own a layer (e.g. Modal), or use the same layerId as an ancestor
+ * that already called `useFocusLayer`.
+ */
+export function useScopedKeyboard(
+  layerId: FocusLayerId,
+  handler: (key: {
+    name?: string;
+    ctrl?: boolean;
+    shift?: boolean;
+    meta?: boolean;
+  }) => void,
+  opts?: { global?: boolean },
+): void {
+  const ctx = useFocusContext();
+
+  useKeyboard(
+    (key: {
+      name?: string;
+      ctrl?: boolean;
+      shift?: boolean;
+      meta?: boolean;
+    }) => {
+      if (opts?.global || ctx.isActive(layerId)) {
+        handler(key);
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Replace the brittle `isModalOpen` prop-threading pattern with a stack-based keyboard focus system. Modals and overlays now automatically claim keyboard focus via `useFocusLayer()`, preventing key leak bugs between layers.

## Problem

`useKeyboard` in @opentui/solid is a global broadcast — all mounted callbacks receive every keypress. The workaround was threading `isModalOpen` props through components so individual handlers could guard against keypresses intended for other layers. This was O(modals × listeners) and required every new handler to know about every modal.

## Solution

A `KeyboardFocusProvider` (Solid context) maintains a reactive stack of focus layer IDs. Components push/pop layers on mount/cleanup. `useScopedKeyboard()` wraps `useKeyboard()` and gates the handler — only fires if the component's layer is topmost.

### Focus layers
| Layer | Components | Behavior |
|-------|-----------|----------|
| `FocusLayer.BASE` | Ctrl+K, Ctrl+Y, Ctrl+P | Always fires (`{ global: true }`) |
| `FocusLayer.APP` | Tab, Escape, Ctrl+E, confirmation Y/N/A, textarea monitors | Suppressed when modal/overlay open |
| `FocusLayer.MODAL` | Modal + children (SessionPicker, ThemePicker) | Pushed by Modal component |
| `FocusLayer.COMMAND_MENU` | Slash command overlay | Pushed by CommandMenu |
| `FocusLayer.FILE_PICKER` | @ file mention overlay | Pushed by FilePicker |

## Changes

### New files (2)
- `src/tui/keyboard/keyboard-focus.tsx` — Provider, hooks, `FocusLayer` constants
- `src/tui/keyboard/index.ts` — Barrel export

### Modified files (10)
- All 10 `useKeyboard` call sites migrated to `useScopedKeyboard`
- All `isModalOpen` prop threading removed (8 references)
- Textarea monitors (`/` and `@`) made global so overlays can close properly
- Removed `status !== 'thinking'` guards — users can now type `/` and `@` while agent is working

### Stats
- +299 lines / -125 lines across 13 files

## Testing
- [x] Build passes
- [x] No remaining raw `useKeyboard` calls outside `keyboard-focus.tsx`
- [x] No remaining `isModalOpen` references (except doc comment)
- [x] No magic string layer IDs — all use `FocusLayer.*` constants
- [x] Manual testing: command menu, file picker, session picker, theme picker, tool confirmation

## Issues
- Closes #58
- Improves #12 (keyboard handler conflicts)
- Improves #16 (confirmation view keyboard/state)
- Improves #57 (confirmation diff preview scroll)