### PR TITLE
feat: add web_fetch tool for fetching and converting web content

### DIFF
--- a/.changeset/web-fetch-tool.md
+++ b/.changeset/web-fetch-tool.md
@@ -1,0 +1,5 @@
+---
+"olliecode": minor
+---
+
+Added `web_fetch` tool for fetching and converting web content. Supports markdown (default), text, and HTML output formats. Uses TurndownService for HTML-to-Markdown conversion and Bun's HTMLRewriter for plain text extraction. Includes content negotiation, Cloudflare bypass, configurable timeout and response size limits. Available in both Plan and Build modes.

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "jsonc-parser": "^3.3.1",
         "ollama": "^0.6.3",
         "solid-js": "1.9.9",
+        "turndown": "^7.2.4",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -25,6 +26,7 @@
         "@types/babel__core": "^7.20.5",
         "@types/bun": "latest",
         "@types/diff": "^8.0.0",
+        "@types/turndown": "^5.0.6",
         "babel-preset-solid": "1.9.9",
         "promptfoo": "^0.120.24",
       },
@@ -554,6 +556,8 @@
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
 
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.26.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg=="],
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.4", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-p7X/ytJDIdwUfFL/CLOhKgdfJe1Fa8uw9seJYvdOmnP9JBWGWHW69HkOixXS6Wy9yvGf1MbhcS6lVmrhy4jm2g=="],
@@ -861,6 +865,8 @@
     "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
 
     "@types/triple-beam": ["@types/triple-beam@1.3.5", "", {}, "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="],
+
+    "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
 
     "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
 
@@ -2141,6 +2147,8 @@
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
 
     "type-fest": ["type-fest@5.4.4", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw=="],
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/babel__core": "^7.20.5",
     "@types/bun": "latest",
     "@types/diff": "^8.0.0",
+    "@types/turndown": "^5.0.6",
     "babel-preset-solid": "1.9.9",
     "promptfoo": "^0.120.24"
   },
@@ -73,6 +74,7 @@
     "jsonc-parser": "^3.3.1",
     "ollama": "^0.6.3",
     "solid-js": "1.9.9",
+    "turndown": "^7.2.4",
     "zod": "^4.3.6"
   }
 }

--- a/src/agent/modes/index.ts
+++ b/src/agent/modes/index.ts
@@ -27,6 +27,7 @@ export const MODE_TOOLS: Record<AgentMode, readonly string[]> = {
     'todo_write',
     'todo_read',
     'task',
+    'web_fetch',
   ] as const,
   build: [
     'read_file',
@@ -39,6 +40,7 @@ export const MODE_TOOLS: Record<AgentMode, readonly string[]> = {
     'todo_write',
     'todo_read',
     'task',
+    'web_fetch',
   ] as const,
 };
 

--- a/src/agent/safety/types.ts
+++ b/src/agent/safety/types.ts
@@ -104,6 +104,7 @@ export const DEFAULT_SAFETY_CONFIG: SafetyConfig = {
     task: 'allow',
     todo_read: 'allow',
     todo_write: 'allow',
+    web_fetch: 'allow',
   },
 
   deniedPaths: [

--- a/src/agent/safety/types.ts
+++ b/src/agent/safety/types.ts
@@ -104,7 +104,7 @@ export const DEFAULT_SAFETY_CONFIG: SafetyConfig = {
     task: 'allow',
     todo_read: 'allow',
     todo_write: 'allow',
-    web_fetch: 'allow',
+    web_fetch: 'ask',
   },
 
   deniedPaths: [

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -1,17 +1,18 @@
-import { z } from 'zod';
 import type { Tool } from 'ollama';
-import type { ToolDefinition, ToolResult, ToolContext } from '../types';
+import { z } from 'zod';
 import type { AgentMode } from '../modes';
 import { MODE_TOOLS } from '../modes';
-import { readFileTool } from './read-file';
-import { listDirTool } from './list-dir';
+import type { ToolContext, ToolDefinition, ToolResult } from '../types';
+import { editFileTool } from './edit-file';
 import { globTool } from './glob';
 import { grepTool } from './grep';
-import { writeFileTool } from './write-file';
-import { editFileTool } from './edit-file';
+import { listDirTool } from './list-dir';
+import { readFileTool } from './read-file';
 import { runCommandTool } from './run-command';
-import { todoWriteTool, todoReadTool } from './todo';
 import { taskTool } from './task';
+import { todoReadTool, todoWriteTool } from './todo';
+import { webFetchTool } from './web-fetch';
+import { writeFileTool } from './write-file';
 
 // All registered tools
 // biome-ignore lint/suspicious/noExplicitAny: Tools array holds heterogeneous tool types with different schemas
@@ -26,6 +27,7 @@ const tools: ToolDefinition<any, any>[] = [
   todoWriteTool,
   todoReadTool,
   taskTool,
+  webFetchTool,
 ];
 
 // Tool name constants for reference
@@ -40,6 +42,7 @@ export const TOOL_NAMES = {
   TODO_WRITE: 'todo_write',
   TODO_READ: 'todo_read',
   TASK: 'task',
+  WEB_FETCH: 'web_fetch',
 } as const;
 
 // Convert ToolDefinition to Ollama Tool format

--- a/src/agent/tools/web-fetch.ts
+++ b/src/agent/tools/web-fetch.ts
@@ -1,0 +1,348 @@
+/**
+ * Web Fetch Tool - Fetches URL content and converts to a readable format.
+ *
+ * Supports three output formats:
+ * - markdown (default): HTML → Markdown via TurndownService
+ * - text: HTML → plain text via Bun's HTMLRewriter
+ * - html: raw HTML passthrough
+ *
+ * Content negotiation: sends Accept: text/markdown when markdown format
+ * is requested — some doc sites serve markdown natively.
+ */
+
+import TurndownService from 'turndown';
+import { z } from 'zod';
+import type { ToolContext, ToolDefinition } from '../types';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_TIMEOUT_MS = 120_000;
+const DEFAULT_MAX_RESPONSE_SIZE = 5 * 1024 * 1024; // 5MB
+
+const OUTPUT_FORMATS = ['markdown', 'text', 'html'] as const;
+type OutputFormat = (typeof OUTPUT_FORMATS)[number];
+
+const ACCEPT_HEADERS: Record<OutputFormat, string> = {
+  markdown:
+    'text/markdown;q=1.0, text/x-markdown;q=0.9, text/plain;q=0.8, text/html;q=0.7, */*;q=0.1',
+  text: 'text/plain;q=1.0, text/markdown;q=0.9, text/html;q=0.8, */*;q=0.1',
+  html: 'text/html;q=1.0, application/xhtml+xml;q=0.9, text/plain;q=0.8, text/markdown;q=0.7, */*;q=0.1',
+};
+
+const USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36';
+
+const HONEST_USER_AGENT = 'ollie';
+
+/** HTML elements stripped before markdown/text conversion */
+const STRIPPED_ELEMENTS = [
+  'script',
+  'style',
+  'meta',
+  'link',
+  'nav',
+  'footer',
+  'header',
+  'noscript',
+  'iframe',
+  'object',
+  'embed',
+] as const;
+
+// ============================================================================
+// Schemas
+// ============================================================================
+
+const inputSchema = z.object({
+  url: z.string().describe('The URL to fetch content from'),
+  format: z
+    .enum(OUTPUT_FORMATS)
+    .optional()
+    .default('markdown')
+    .describe('Output format: "markdown" (default), "text", or "html"'),
+  timeout: z
+    .number()
+    .optional()
+    .describe('Timeout in seconds (default 30, max 120)'),
+});
+
+const outputSchema = z
+  .string()
+  .describe('The fetched content in the requested format');
+
+// ============================================================================
+// HTML Conversion
+// ============================================================================
+
+function convertHTMLToMarkdown(html: string): string {
+  const turndown = new TurndownService({
+    headingStyle: 'atx',
+    hr: '---',
+    bulletListMarker: '-',
+    codeBlockStyle: 'fenced',
+    emDelimiter: '*',
+  });
+
+  turndown.remove(STRIPPED_ELEMENTS as unknown as string[]);
+
+  return turndown.turndown(html);
+}
+
+/** Block-level elements that should have whitespace separation in text output */
+const BLOCK_ELEMENTS = new Set([
+  'div',
+  'p',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'li',
+  'tr',
+  'br',
+  'blockquote',
+  'pre',
+  'section',
+  'article',
+  'aside',
+  'main',
+  'dt',
+  'dd',
+]);
+
+async function extractTextFromHTML(html: string): Promise<string> {
+  let text = '';
+  let skipContent = false;
+
+  const skipTags = new Set(STRIPPED_ELEMENTS);
+
+  const rewriter = new HTMLRewriter()
+    .on(STRIPPED_ELEMENTS.join(', '), {
+      element() {
+        skipContent = true;
+      },
+      text() {
+        // Discard text inside stripped elements
+      },
+    })
+    .on('*', {
+      element(element) {
+        if (
+          !skipTags.has(element.tagName as (typeof STRIPPED_ELEMENTS)[number])
+        ) {
+          skipContent = false;
+          // Add newline before block elements for readable spacing
+          if (BLOCK_ELEMENTS.has(element.tagName) && text.length > 0) {
+            text += '\n';
+          }
+        }
+      },
+      text(input) {
+        if (!skipContent) {
+          text += input.text;
+        }
+      },
+    })
+    .transform(new Response(html));
+
+  await rewriter.text();
+
+  // Collapse runs of whitespace into single newlines for readability
+  return text
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n /g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+// ============================================================================
+// Fetch Logic
+// ============================================================================
+
+/**
+ * Perform the HTTP fetch with content negotiation, timeout, and Cloudflare retry.
+ */
+async function fetchURL(
+  url: string,
+  format: OutputFormat,
+  timeoutMs: number,
+  signal?: AbortSignal,
+  maxResponseSize: number = DEFAULT_MAX_RESPONSE_SIZE,
+): Promise<{ content: string; contentType: string }> {
+  const headers: Record<string, string> = {
+    'User-Agent': USER_AGENT,
+    Accept: ACCEPT_HEADERS[format],
+    'Accept-Language': 'en-US,en;q=0.9',
+  };
+
+  const controller = new AbortController();
+
+  // Combine external abort signal with our timeout
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  if (signal) {
+    signal.addEventListener('abort', () => controller.abort(), { once: true });
+  }
+
+  try {
+    let response = await fetch(url, {
+      headers,
+      signal: controller.signal,
+      redirect: 'follow',
+    });
+
+    // Cloudflare bot detection: retry with honest UA
+    if (
+      response.status === 403 &&
+      response.headers.get('cf-mitigated') === 'challenge'
+    ) {
+      response = await fetch(url, {
+        headers: { ...headers, 'User-Agent': HONEST_USER_AGENT },
+        signal: controller.signal,
+        redirect: 'follow',
+      });
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `HTTP ${response.status}: ${response.statusText} for ${url}`,
+      );
+    }
+
+    // Check content-length header before downloading body
+    const contentLength = response.headers.get('content-length');
+    if (contentLength && Number.parseInt(contentLength, 10) > maxResponseSize) {
+      throw new Error(
+        `Response too large: ${contentLength} bytes exceeds ${maxResponseSize} byte limit`,
+      );
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    if (arrayBuffer.byteLength > maxResponseSize) {
+      throw new Error(
+        `Response too large: ${arrayBuffer.byteLength} bytes exceeds ${maxResponseSize} byte limit`,
+      );
+    }
+
+    const contentType = response.headers.get('content-type') ?? '';
+    const content = new TextDecoder().decode(arrayBuffer);
+
+    return { content, contentType };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+// ============================================================================
+// Format Routing
+// ============================================================================
+
+async function formatContent(
+  content: string,
+  contentType: string,
+  format: OutputFormat,
+): Promise<string> {
+  const isHTML = contentType.includes('text/html');
+
+  // html format: always return raw
+  if (format === 'html') {
+    return content;
+  }
+
+  // If the response isn't HTML, return as-is (could be markdown, plain text, JSON, etc.)
+  if (!isHTML) {
+    return content;
+  }
+
+  // HTML content — convert to requested format
+  if (format === 'text') {
+    return extractTextFromHTML(content);
+  }
+
+  // markdown (default)
+  return convertHTMLToMarkdown(content);
+}
+
+// ============================================================================
+// Tool Definition
+// ============================================================================
+
+export const webFetchTool: ToolDefinition<
+  typeof inputSchema,
+  typeof outputSchema
+> = {
+  name: 'web_fetch',
+  description: `Fetch content from a URL and return it in a readable format.
+
+Use this tool to retrieve web content for documentation lookup, API references, or external resources.
+
+Parameters:
+- url: The URL to fetch (required, must start with http:// or https://)
+- format: Output format — "markdown" (default), "text", or "html"
+- timeout: Request timeout in seconds (optional, default 30, max 120)
+
+Format details:
+- markdown: Converts HTML to clean Markdown. Best for documentation, articles, and web pages. Preserves headings, code blocks, links, and lists.
+- text: Extracts plain text from HTML. Strips all markup. Use when you only need raw text content.
+- html: Returns raw HTML. Use when you need to inspect the page structure.
+
+Content negotiation: When markdown format is requested, the Accept header prefers text/markdown — some documentation sites serve markdown directly, avoiding lossy conversion.
+
+Notes:
+- Maximum response size is 5MB
+- Non-HTML responses (JSON, plain text, markdown) are returned as-is regardless of format
+- Images and binary content are not supported`,
+
+  parameters: inputSchema,
+  outputSchema,
+  risk: 'safe',
+
+  execute: async (
+    params: { url: string; format?: OutputFormat; timeout?: number },
+    signal?: AbortSignal,
+    context?: ToolContext,
+  ) => {
+    const { url, format = 'markdown' } = params;
+
+    // Validate URL scheme
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      return `Error: URL must start with http:// or https:// — received: ${url}`;
+    }
+
+    // Resolve timeout from params → config → default
+    const configTimeout =
+      context?.toolsConfig?.web_fetch.timeout ?? DEFAULT_TIMEOUT_MS;
+    const timeoutMs = params.timeout
+      ? Math.min(params.timeout * 1000, MAX_TIMEOUT_MS)
+      : configTimeout;
+
+    const maxResponseSize =
+      context?.toolsConfig?.web_fetch.maxResponseSize ??
+      DEFAULT_MAX_RESPONSE_SIZE;
+
+    try {
+      const { content, contentType } = await fetchURL(
+        url,
+        format,
+        timeoutMs,
+        signal,
+        maxResponseSize,
+      );
+
+      const formatted = await formatContent(content, contentType, format);
+
+      return `<web_fetch url="${url}" format="${format}" content_type="${contentType}">\n${formatted}\n</web_fetch>`;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (message.includes('abort')) {
+        return `Error: Request timed out after ${Math.round(timeoutMs / 1000)}s for ${url}`;
+      }
+
+      return `Error fetching ${url}: ${message}`;
+    }
+  },
+};

--- a/src/agent/tools/web-fetch.ts
+++ b/src/agent/tools/web-fetch.ts
@@ -10,6 +10,7 @@
  * is requested — some doc sites serve markdown natively.
  *
  * Security: blocks requests to private/reserved IP ranges (SSRF protection).
+ * Redirects are followed manually with per-hop SSRF validation.
  */
 
 import TurndownService from 'turndown';
@@ -24,6 +25,7 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_TIMEOUT_MS = 120_000;
 const DEFAULT_MAX_RESPONSE_SIZE = 5 * 1024 * 1024; // 5MB
 const DEFAULT_MAX_OUTPUT_CHARS = 50_000; // ~12K tokens
+const MAX_REDIRECTS = 5;
 
 const OUTPUT_FORMATS = ['markdown', 'text', 'html'] as const;
 type OutputFormat = (typeof OUTPUT_FORMATS)[number];
@@ -68,7 +70,7 @@ const DENIED_HOSTS = new Set([
   'metadata.google.internal',
 ]);
 
-/** IP patterns for private/reserved ranges */
+/** IP patterns for private/reserved ranges (IPv4 + IPv6 + IPv4-mapped IPv6) */
 const DENIED_IP_PATTERNS = [
   /^127\./, // Loopback
   /^10\./, // RFC 1918 Class A
@@ -81,11 +83,21 @@ const DENIED_IP_PATTERNS = [
   /^fc00:/i, // IPv6 unique local
   /^fe80:/i, // IPv6 link-local
   /^fd/i, // IPv6 unique local
+  // IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
+  /^::ffff:(127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|169\.254\.|0\.)/i,
 ];
 
 /**
+ * Check if a resolved IP address is private/reserved.
+ */
+function isPrivateIP(addr: string): boolean {
+  return DENIED_IP_PATTERNS.some((pattern) => pattern.test(addr));
+}
+
+/**
  * Validate a URL is not targeting private/internal networks.
- * Resolves hostname to IP and checks against denied ranges.
+ * Uses dns.lookup() (OS resolver) to match what fetch() will actually connect to.
+ * Denies by default on resolution failure.
  */
 async function validateURLSafety(url: string): Promise<string | null> {
   let parsed: URL;
@@ -102,20 +114,17 @@ async function validateURLSafety(url: string): Promise<string | null> {
     return `Blocked: requests to ${hostname} are not allowed (private/reserved address)`;
   }
 
-  // Resolve hostname to IP and check
+  // Resolve hostname to IP via OS resolver and check
   try {
-    const { resolve } = await import('node:dns/promises');
-    const addresses = await resolve(hostname).catch(() => [hostname]);
+    const dns = await import('node:dns/promises');
+    const { address } = await dns.lookup(hostname);
 
-    for (const addr of addresses) {
-      for (const pattern of DENIED_IP_PATTERNS) {
-        if (pattern.test(addr)) {
-          return `Blocked: ${hostname} resolves to private address ${addr}`;
-        }
-      }
+    if (isPrivateIP(address)) {
+      return `Blocked: ${hostname} resolves to private address ${address}`;
     }
   } catch {
-    // DNS resolution failed — let fetch handle it
+    // DNS resolution failed — deny by default for safety
+    return `Blocked: could not resolve ${hostname} — cannot verify address safety`;
   }
 
   return null; // Safe
@@ -263,7 +272,8 @@ async function extractTextFromHTML(html: string): Promise<string> {
 // ============================================================================
 
 /**
- * Perform the HTTP fetch with content negotiation, timeout, and Cloudflare retry.
+ * Perform the HTTP fetch with content negotiation, timeout, Cloudflare retry,
+ * and manual redirect following with per-hop SSRF validation.
  */
 async function fetchURL(
   url: string,
@@ -289,11 +299,57 @@ async function fetchURL(
   }
 
   try {
-    let response = await fetch(url, {
-      headers,
-      signal: controller.signal,
-      redirect: 'follow',
-    });
+    let currentUrl = url;
+    let redirectCount = 0;
+    let response: Response;
+
+    // Manual redirect loop with per-hop SSRF validation
+    while (true) {
+      response = await fetch(currentUrl, {
+        headers,
+        signal: controller.signal,
+        redirect: 'manual',
+      });
+
+      // Handle redirects (3xx)
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get('location');
+        if (!location) {
+          // Consume body before throwing
+          await response.arrayBuffer().catch(() => {});
+          throw new Error(
+            `HTTP ${response.status} redirect with no Location header`,
+          );
+        }
+
+        redirectCount++;
+        if (redirectCount > MAX_REDIRECTS) {
+          await response.arrayBuffer().catch(() => {});
+          throw new Error(
+            `Too many redirects (${MAX_REDIRECTS}) following ${url}`,
+          );
+        }
+
+        // Consume redirect response body
+        await response.arrayBuffer().catch(() => {});
+
+        // Resolve relative redirect URLs
+        const redirectUrl = new URL(location, currentUrl).toString();
+
+        // Validate redirect target for SSRF
+        const ssrfError = await validateURLSafety(redirectUrl);
+        if (ssrfError) {
+          throw new Error(
+            `Redirect blocked: ${currentUrl} → ${redirectUrl} — ${ssrfError}`,
+          );
+        }
+
+        currentUrl = redirectUrl;
+        continue;
+      }
+
+      break;
+    }
 
     // Cloudflare bot detection: retry with honest UA
     if (
@@ -303,22 +359,25 @@ async function fetchURL(
       // Consume the first response body to prevent resource leak
       await response.arrayBuffer().catch(() => {});
 
-      response = await fetch(url, {
+      response = await fetch(currentUrl, {
         headers: { ...headers, 'User-Agent': HONEST_USER_AGENT },
         signal: controller.signal,
-        redirect: 'follow',
+        redirect: 'manual',
       });
     }
 
     if (!response.ok) {
+      // Consume body before throwing to prevent resource leak
+      await response.arrayBuffer().catch(() => {});
       throw new Error(
-        `HTTP ${response.status}: ${response.statusText} for ${url}`,
+        `HTTP ${response.status}: ${response.statusText} for ${currentUrl}`,
       );
     }
 
     // Check content-length header before downloading body
     const contentLength = response.headers.get('content-length');
     if (contentLength && Number.parseInt(contentLength, 10) > maxResponseSize) {
+      await response.arrayBuffer().catch(() => {});
       throw new Error(
         `Response too large: ${contentLength} bytes exceeds ${maxResponseSize} byte limit`,
       );
@@ -402,7 +461,12 @@ async function formatContent(
 
 /** Escape characters that would break the XML-like output wrapper */
 function escapeAttr(value: string): string {
-  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 // ============================================================================
@@ -460,18 +524,18 @@ Notes:
 
     // Resolve timeout from params → config → default, always clamped
     const configTimeout =
-      context?.toolsConfig?.web_fetch.timeout ?? DEFAULT_TIMEOUT_MS;
+      context?.toolsConfig?.web_fetch?.timeout ?? DEFAULT_TIMEOUT_MS;
     const timeoutMs = Math.min(
       params.timeout ? params.timeout * 1000 : configTimeout,
       MAX_TIMEOUT_MS,
     );
 
     const maxResponseSize =
-      context?.toolsConfig?.web_fetch.maxResponseSize ??
+      context?.toolsConfig?.web_fetch?.maxResponseSize ??
       DEFAULT_MAX_RESPONSE_SIZE;
 
     const maxOutputChars =
-      context?.toolsConfig?.web_fetch.maxOutputChars ??
+      context?.toolsConfig?.web_fetch?.maxOutputChars ??
       DEFAULT_MAX_OUTPUT_CHARS;
 
     try {

--- a/src/agent/tools/web-fetch.ts
+++ b/src/agent/tools/web-fetch.ts
@@ -8,6 +8,8 @@
  *
  * Content negotiation: sends Accept: text/markdown when markdown format
  * is requested — some doc sites serve markdown natively.
+ *
+ * Security: blocks requests to private/reserved IP ranges (SSRF protection).
  */
 
 import TurndownService from 'turndown';
@@ -21,6 +23,7 @@ import type { ToolContext, ToolDefinition } from '../types';
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_TIMEOUT_MS = 120_000;
 const DEFAULT_MAX_RESPONSE_SIZE = 5 * 1024 * 1024; // 5MB
+const DEFAULT_MAX_OUTPUT_CHARS = 50_000; // ~12K tokens
 
 const OUTPUT_FORMATS = ['markdown', 'text', 'html'] as const;
 type OutputFormat = (typeof OUTPUT_FORMATS)[number];
@@ -53,6 +56,72 @@ const STRIPPED_ELEMENTS = [
 ] as const;
 
 // ============================================================================
+// SSRF Protection
+// ============================================================================
+
+/** Hosts always blocked regardless of resolution */
+const DENIED_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '[::1]',
+  '0.0.0.0',
+  'metadata.google.internal',
+]);
+
+/** IP patterns for private/reserved ranges */
+const DENIED_IP_PATTERNS = [
+  /^127\./, // Loopback
+  /^10\./, // RFC 1918 Class A
+  /^172\.(1[6-9]|2\d|3[01])\./, // RFC 1918 Class B
+  /^192\.168\./, // RFC 1918 Class C
+  /^169\.254\./, // Link-local
+  /^0\./, // Current network
+  /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./, // Shared address space (CGN)
+  /^::1$/, // IPv6 loopback
+  /^fc00:/i, // IPv6 unique local
+  /^fe80:/i, // IPv6 link-local
+  /^fd/i, // IPv6 unique local
+];
+
+/**
+ * Validate a URL is not targeting private/internal networks.
+ * Resolves hostname to IP and checks against denied ranges.
+ */
+async function validateURLSafety(url: string): Promise<string | null> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return 'Invalid URL format';
+  }
+
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, ''); // Strip IPv6 brackets
+
+  // Check denied hostnames
+  if (DENIED_HOSTS.has(hostname.toLowerCase())) {
+    return `Blocked: requests to ${hostname} are not allowed (private/reserved address)`;
+  }
+
+  // Resolve hostname to IP and check
+  try {
+    const { resolve } = await import('node:dns/promises');
+    const addresses = await resolve(hostname).catch(() => [hostname]);
+
+    for (const addr of addresses) {
+      for (const pattern of DENIED_IP_PATTERNS) {
+        if (pattern.test(addr)) {
+          return `Blocked: ${hostname} resolves to private address ${addr}`;
+        }
+      }
+    }
+  } catch {
+    // DNS resolution failed — let fetch handle it
+  }
+
+  return null; // Safe
+}
+
+// ============================================================================
 // Schemas
 // ============================================================================
 
@@ -65,6 +134,8 @@ const inputSchema = z.object({
     .describe('Output format: "markdown" (default), "text", or "html"'),
   timeout: z
     .number()
+    .int()
+    .min(1)
     .optional()
     .describe('Timeout in seconds (default 30, max 120)'),
 });
@@ -77,17 +148,17 @@ const outputSchema = z
 // HTML Conversion
 // ============================================================================
 
+/** Module-level TurndownService singleton — config is static */
+const turndown = new TurndownService({
+  headingStyle: 'atx',
+  hr: '---',
+  bulletListMarker: '-',
+  codeBlockStyle: 'fenced',
+  emDelimiter: '*',
+});
+turndown.remove([...STRIPPED_ELEMENTS]);
+
 function convertHTMLToMarkdown(html: string): string {
-  const turndown = new TurndownService({
-    headingStyle: 'atx',
-    hr: '---',
-    bulletListMarker: '-',
-    codeBlockStyle: 'fenced',
-    emDelimiter: '*',
-  });
-
-  turndown.remove(STRIPPED_ELEMENTS as unknown as string[]);
-
   return turndown.turndown(html);
 }
 
@@ -114,27 +185,55 @@ const BLOCK_ELEMENTS = new Set([
   'dd',
 ]);
 
+/**
+ * Stripped elements split by whether they can have children.
+ * Void elements (meta, link, embed) never have end tags — onEndTag throws.
+ * Container elements (script, style, etc.) need depth tracking.
+ */
+const STRIPPED_CONTAINERS = [
+  'script',
+  'style',
+  'nav',
+  'footer',
+  'header',
+  'noscript',
+  'iframe',
+  'object',
+] as const;
+
+const STRIPPED_VOID = ['meta', 'link', 'embed'] as const;
+
 async function extractTextFromHTML(html: string): Promise<string> {
   let text = '';
-  let skipContent = false;
+  let skipDepth = 0;
 
   const skipTags = new Set(STRIPPED_ELEMENTS);
 
   const rewriter = new HTMLRewriter()
-    .on(STRIPPED_ELEMENTS.join(', '), {
-      element() {
-        skipContent = true;
+    .on(STRIPPED_CONTAINERS.join(', '), {
+      element(element) {
+        skipDepth++;
+        element.onEndTag(() => {
+          skipDepth--;
+        });
       },
       text() {
-        // Discard text inside stripped elements
+        // Discard text inside stripped container elements
       },
+    })
+    .on(STRIPPED_VOID.join(', '), {
+      // Void elements: no children, no end tag — just mark as skip
+      element() {},
+      text() {},
     })
     .on('*', {
       element(element) {
+        if (skipDepth > 0) {
+          return;
+        }
         if (
           !skipTags.has(element.tagName as (typeof STRIPPED_ELEMENTS)[number])
         ) {
-          skipContent = false;
           // Add newline before block elements for readable spacing
           if (BLOCK_ELEMENTS.has(element.tagName) && text.length > 0) {
             text += '\n';
@@ -142,7 +241,7 @@ async function extractTextFromHTML(html: string): Promise<string> {
         }
       },
       text(input) {
-        if (!skipContent) {
+        if (skipDepth === 0) {
           text += input.text;
         }
       },
@@ -183,8 +282,10 @@ async function fetchURL(
 
   // Combine external abort signal with our timeout
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  const onExternalAbort = () => controller.abort();
   if (signal) {
-    signal.addEventListener('abort', () => controller.abort(), { once: true });
+    signal.addEventListener('abort', onExternalAbort, { once: true });
   }
 
   try {
@@ -199,6 +300,9 @@ async function fetchURL(
       response.status === 403 &&
       response.headers.get('cf-mitigated') === 'challenge'
     ) {
+      // Consume the first response body to prevent resource leak
+      await response.arrayBuffer().catch(() => {});
+
       response = await fetch(url, {
         headers: { ...headers, 'User-Agent': HONEST_USER_AGENT },
         signal: controller.signal,
@@ -233,7 +337,33 @@ async function fetchURL(
     return { content, contentType };
   } finally {
     clearTimeout(timeoutId);
+    // Remove the abort listener to prevent leaks on long-lived signals
+    if (signal) {
+      signal.removeEventListener('abort', onExternalAbort);
+    }
   }
+}
+
+// ============================================================================
+// Output Truncation
+// ============================================================================
+
+/**
+ * Truncate output to stay within context window limits.
+ * Returns the truncated string with a notice if content was cut.
+ */
+function truncateOutput(content: string, maxChars: number): string {
+  if (content.length <= maxChars) {
+    return content;
+  }
+
+  const truncated = content.slice(0, maxChars);
+
+  // Try to break at a newline boundary for cleaner output
+  const lastNewline = truncated.lastIndexOf('\n', maxChars - 200);
+  const breakPoint = lastNewline > maxChars * 0.8 ? lastNewline : maxChars;
+
+  return `${truncated.slice(0, breakPoint)}\n\n[Content truncated at ${maxChars.toLocaleString()} chars (${content.length.toLocaleString()} total). Use format="text" for a more compact view, or fetch a more specific URL.]`;
 }
 
 // ============================================================================
@@ -267,6 +397,15 @@ async function formatContent(
 }
 
 // ============================================================================
+// Utility
+// ============================================================================
+
+/** Escape characters that would break the XML-like output wrapper */
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}
+
+// ============================================================================
 // Tool Definition
 // ============================================================================
 
@@ -292,13 +431,14 @@ Format details:
 Content negotiation: When markdown format is requested, the Accept header prefers text/markdown — some documentation sites serve markdown directly, avoiding lossy conversion.
 
 Notes:
-- Maximum response size is 5MB
+- Maximum response size is 5MB; output is truncated to ~50K chars to fit context window
 - Non-HTML responses (JSON, plain text, markdown) are returned as-is regardless of format
-- Images and binary content are not supported`,
+- Images and binary content are not supported
+- Requests to private/internal networks are blocked for security`,
 
   parameters: inputSchema,
   outputSchema,
-  risk: 'safe',
+  risk: 'low',
 
   execute: async (
     params: { url: string; format?: OutputFormat; timeout?: number },
@@ -312,16 +452,27 @@ Notes:
       return `Error: URL must start with http:// or https:// — received: ${url}`;
     }
 
-    // Resolve timeout from params → config → default
+    // SSRF protection — block private/reserved addresses
+    const ssrfError = await validateURLSafety(url);
+    if (ssrfError) {
+      return `Error: ${ssrfError}`;
+    }
+
+    // Resolve timeout from params → config → default, always clamped
     const configTimeout =
       context?.toolsConfig?.web_fetch.timeout ?? DEFAULT_TIMEOUT_MS;
-    const timeoutMs = params.timeout
-      ? Math.min(params.timeout * 1000, MAX_TIMEOUT_MS)
-      : configTimeout;
+    const timeoutMs = Math.min(
+      params.timeout ? params.timeout * 1000 : configTimeout,
+      MAX_TIMEOUT_MS,
+    );
 
     const maxResponseSize =
       context?.toolsConfig?.web_fetch.maxResponseSize ??
       DEFAULT_MAX_RESPONSE_SIZE;
+
+    const maxOutputChars =
+      context?.toolsConfig?.web_fetch.maxOutputChars ??
+      DEFAULT_MAX_OUTPUT_CHARS;
 
     try {
       const { content, contentType } = await fetchURL(
@@ -333,15 +484,16 @@ Notes:
       );
 
       const formatted = await formatContent(content, contentType, format);
+      const output = truncateOutput(formatted, maxOutputChars);
 
-      return `<web_fetch url="${url}" format="${format}" content_type="${contentType}">\n${formatted}\n</web_fetch>`;
+      return `<web_fetch url="${escapeAttr(url)}" format="${format}" content_type="${escapeAttr(contentType)}">\n${output}\n</web_fetch>`;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-
-      if (message.includes('abort')) {
+      // Distinguish timeout/abort from other errors
+      if (error instanceof DOMException && error.name === 'AbortError') {
         return `Error: Request timed out after ${Math.round(timeoutMs / 1000)}s for ${url}`;
       }
 
+      const message = error instanceof Error ? error.message : String(error);
       return `Error fetching ${url}: ${message}`;
     }
   },

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -20,7 +20,11 @@ export type ToolsConfig = {
   task: {
     iterationLimits: { quick: number; medium: number; thorough: number };
   };
-  web_fetch: { timeout: number; maxResponseSize: number };
+  web_fetch: {
+    timeout: number;
+    maxResponseSize: number;
+    maxOutputChars: number;
+  };
 };
 
 /**

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -20,6 +20,7 @@ export type ToolsConfig = {
   task: {
     iterationLimits: { quick: number; medium: number; thorough: number };
   };
+  web_fetch: { timeout: number; maxResponseSize: number };
 };
 
 /**

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -177,6 +177,10 @@ export function extractToolsConfig(config: ResolvedConfig): ToolsConfig {
         thorough: config.tools.task.iterationLimits.thorough,
       },
     },
+    web_fetch: {
+      timeout: config.tools.web_fetch.timeout,
+      maxResponseSize: config.tools.web_fetch.maxResponseSize,
+    },
   };
 }
 

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -45,6 +45,7 @@ const AUTONOMY_BASELINES: Record<string, ToolPermissionMap> = {
     task: 'ask',
     todo_read: 'ask',
     todo_write: 'ask',
+    web_fetch: 'ask',
   },
   cautious: {
     read_file: 'allow',
@@ -57,6 +58,7 @@ const AUTONOMY_BASELINES: Record<string, ToolPermissionMap> = {
     task: 'allow',
     todo_read: 'allow',
     todo_write: 'allow',
+    web_fetch: 'ask',
   },
   balanced: {
     read_file: 'allow',
@@ -69,6 +71,7 @@ const AUTONOMY_BASELINES: Record<string, ToolPermissionMap> = {
     task: 'allow',
     todo_read: 'allow',
     todo_write: 'allow',
+    web_fetch: 'allow',
   },
   autonomous: {
     read_file: 'allow',
@@ -81,6 +84,7 @@ const AUTONOMY_BASELINES: Record<string, ToolPermissionMap> = {
     task: 'allow',
     todo_read: 'allow',
     todo_write: 'allow',
+    web_fetch: 'allow',
   },
 };
 
@@ -180,6 +184,7 @@ export function extractToolsConfig(config: ResolvedConfig): ToolsConfig {
     web_fetch: {
       timeout: config.tools.web_fetch.timeout,
       maxResponseSize: config.tools.web_fetch.maxResponseSize,
+      maxOutputChars: config.tools.web_fetch.maxOutputChars,
     },
   };
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -114,6 +114,16 @@ const TaskToolObjectSchema = z.object({
   ),
 });
 
+const WebFetchToolObjectSchema = z.object({
+  timeout: z.number().int().min(1000).max(120000).default(30000),
+  maxResponseSize: z
+    .number()
+    .int()
+    .min(1024)
+    .max(10 * 1024 * 1024)
+    .default(5 * 1024 * 1024),
+});
+
 const ToolsObjectSchema = z.object({
   read_file: ReadFileToolObjectSchema.default(() =>
     ReadFileToolObjectSchema.parse({}),
@@ -122,6 +132,9 @@ const ToolsObjectSchema = z.object({
     RunCommandToolObjectSchema.parse({}),
   ),
   task: TaskToolObjectSchema.default(() => TaskToolObjectSchema.parse({})),
+  web_fetch: WebFetchToolObjectSchema.default(() =>
+    WebFetchToolObjectSchema.parse({}),
+  ),
 });
 
 export const ToolsSchema = ToolsObjectSchema.default(() =>

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -122,6 +122,7 @@ const WebFetchToolObjectSchema = z.object({
     .min(1024)
     .max(10 * 1024 * 1024)
     .default(5 * 1024 * 1024),
+  maxOutputChars: z.number().int().min(1000).max(500_000).default(50_000),
 });
 
 const ToolsObjectSchema = z.object({


### PR DESCRIPTION
## Summary

Adds a new `web_fetch` tool that retrieves URL content and converts it to markdown (default), plain text, or raw HTML. Uses TurndownService for HTML-to-Markdown and Bun's HTMLRewriter for text extraction.

Closes #17

## Features

- **Three output formats**: markdown (default), text, html
- **Content negotiation**: `Accept: text/markdown` header — doc sites that serve markdown natively skip lossy conversion
- **SSRF protection**: Blocks private/reserved IP ranges (RFC 1918, loopback, link-local, cloud metadata, IPv4-mapped IPv6). DNS resolution via `dns.lookup()` (OS resolver). Manual redirect following with per-hop SSRF validation.
- **Output truncation**: 50K char default cap (~12K tokens) to protect context window
- **Cloudflare bypass**: Retries with honest UA on 403 + `cf-mitigated: challenge`
- **Configurable**: timeout (30s default, 120s max), max response size (5MB), max output chars — all via `.ollie.json`
- **Available in Plan + Build modes**

## Security

- `risk: 'low'` — requires confirmation in paranoid/cautious autonomy modes
- Added to all 4 AUTONOMY_BASELINES levels (ask in paranoid/cautious, allow in balanced/autonomous)
- SSRF: hostname denylist + DNS resolution + IP pattern matching + redirect validation
- Response bodies consumed on all error paths (no resource leaks)
- Abort signal listener cleanup in finally block
- XML output wrapper attributes escaped

## Accepted risks (documented)

- **DNS rebinding TOCTOU**: Inherent to resolve-then-fetch pattern. Acceptable for local dev tool.
- **Prompt injection**: Fetched content goes to LLM as-is. Same exposure as every AI coding tool.
- **No rate limiting**: Capped by existing `maxToolCallsPerSession`.

## Files changed

- `src/agent/tools/web-fetch.ts` — **new** (540 lines)
- `src/agent/tools/index.ts` — registered + TOOL_NAMES
- `src/agent/modes/index.ts` — plan + build
- `src/agent/safety/types.ts` — permission default
- `src/agent/types.ts` — ToolsConfig type
- `src/config/resolve.ts` — AUTONOMY_BASELINES + extractToolsConfig
- `src/config/schema.ts` — WebFetchToolObjectSchema
- `package.json` / `bun.lock` — turndown deps
- `.changeset/web-fetch-tool.md`

## Testing

9 manual tests passing: markdown, text, invalid URL, SSRF (localhost, 169.254, 10.x, 192.168.x), JSON passthrough, redirect following.