### PR TITLE
feat(mcp): tool registration & execution (#90)

### DIFF
--- a/src/agent/mcp/index.ts
+++ b/src/agent/mcp/index.ts
@@ -2,7 +2,7 @@
  * MCP module — re-exports for external consumption.
  */
 
-export { McpManager } from './manager';
+export { McpManager, createMcpToolDef } from './manager';
 export type { McpContentItem, McpToolsChangedListener } from './manager';
 
 export {

--- a/src/agent/mcp/manager.ts
+++ b/src/agent/mcp/manager.ts
@@ -13,17 +13,20 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import { z, fromJSONSchema } from 'zod';
 import type {
   McpLocalServerConfig,
   McpServerConfig,
 } from '../../config/schema';
 import { expandArray, expandRecord } from '../../config/env-expand';
+import type { ToolDefinition } from '../types';
 import type {
   McpConnectionStatus,
   McpStatusMap,
   McpToolAnnotations,
   McpToolInfo,
 } from './types';
+import { mcpAnnotationsToRisk } from './types';
 
 // Package version for MCP client identification
 const PKG_VERSION = '0.5.1';
@@ -72,9 +75,101 @@ function timeoutPromise(
   return { promise, cancel: () => clearTimeout(timer!) };
 }
 
+/**
+ * Create a ToolDefinition from an MCP tool discovery result.
+ *
+ * Uses fromJSONSchema() for real Zod validation of MCP tool parameters.
+ * Falls back to z.any() only when the JSON Schema is too exotic to convert.
+ */
+export function createMcpToolDef(
+  mcpTool: McpToolInfo,
+  client: Client,
+  serverTimeout: number,
+  maxOutputChars: number,
+  // biome-ignore lint/suspicious/noExplicitAny: MCP tools have dynamic schemas
+): ToolDefinition<any, any> {
+  // Convert JSON Schema -> Zod for real validation
+  let zodParams: z.ZodType;
+  try {
+    zodParams = fromJSONSchema(mcpTool.inputSchema);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    console.warn(
+      `MCP tool ${mcpTool.qualifiedName}: JSON Schema conversion failed, falling back to z.any(): ${message}`,
+    );
+    zodParams = z.any();
+  }
+
+  return {
+    name: mcpTool.qualifiedName,
+    description: mcpTool.description,
+    parameters: zodParams,
+    rawInputSchema: mcpTool.inputSchema,
+    outputSchema: z.string(),
+    risk: mcpAnnotationsToRisk(mcpTool.annotations),
+    execute: async (args: unknown, _signal?: AbortSignal) => {
+      const result = await client.callTool(
+        {
+          name: mcpTool.name,
+          arguments: (args as Record<string, unknown>) ?? {},
+        },
+        undefined,
+        { timeout: serverTimeout },
+      );
+
+      // Serialize MCP content array to string
+      const parts: string[] = [];
+      const contentItems = (result.content ?? []) as McpContentItem[];
+      for (const item of contentItems) {
+        switch (item.type) {
+          case 'text':
+            parts.push((item as { type: 'text'; text: string }).text);
+            break;
+          case 'image':
+            parts.push(
+              `[Image content (${(item as { type: 'image'; mimeType: string }).mimeType}) omitted — not supported by current model]`,
+            );
+            break;
+          case 'resource': {
+            const res = (
+              item as {
+                type: 'resource';
+                resource: { uri: string; text?: string };
+              }
+            ).resource;
+            const text = res?.text ?? '';
+            parts.push(text || `[Resource: ${res?.uri}]`);
+            break;
+          }
+          default:
+            parts.push(`[${item.type} content omitted — not supported]`);
+        }
+      }
+
+      let output = parts.join('\n');
+
+      // Truncate to maxOutputChars
+      if (output.length > maxOutputChars) {
+        output =
+          output.slice(0, maxOutputChars) +
+          `\n\n[OUTPUT TRUNCATED — showing first ${maxOutputChars.toLocaleString()} chars]`;
+      }
+
+      if (result.isError) {
+        throw new Error(output || 'MCP tool returned an error with no content');
+      }
+
+      return output;
+    },
+  };
+}
+
 export class McpManager {
   private connections = new Map<string, McpConnection>();
   private toolsChangedListeners: McpToolsChangedListener[] = [];
+  /** MCP ToolDefinitions currently registered in the shared tools array */
+  // biome-ignore lint/suspicious/noExplicitAny: MCP tools have dynamic schemas
+  private registeredToolDefs: ToolDefinition<any, any>[] = [];
 
   static readonly TOOL_COUNT_WARNING_THRESHOLD = 30;
 
@@ -346,6 +441,69 @@ export class McpManager {
       const idx = this.toolsChangedListeners.indexOf(listener);
       if (idx >= 0) this.toolsChangedListeners.splice(idx, 1);
     };
+  }
+
+  /**
+   * Register MCP tools into the shared tools array as ToolDefinitions.
+   * Called after connectAll() or when tools change dynamically.
+   *
+   * @param toolsArray - The mutable shared tools array from tools/index.ts
+   * @param maxOutputChars - Max chars for MCP tool output truncation
+   */
+  registerTools(
+    // biome-ignore lint/suspicious/noExplicitAny: Shared tools array holds heterogeneous types
+    toolsArray: ToolDefinition<any, any>[],
+    maxOutputChars: number,
+  ): void {
+    // First remove any previously registered MCP tools
+    this.unregisterTools(toolsArray);
+
+    const newDefs: ToolDefinition<any, any>[] = [];
+
+    for (const conn of this.connections.values()) {
+      if (conn.status !== 'connected' || !conn.client) continue;
+
+      for (const mcpTool of conn.tools) {
+        const def = createMcpToolDef(
+          mcpTool,
+          conn.client,
+          conn.config.timeout,
+          maxOutputChars,
+        );
+        newDefs.push(def);
+      }
+    }
+
+    // Push into shared array
+    toolsArray.push(...newDefs);
+    this.registeredToolDefs = newDefs;
+  }
+
+  /**
+   * Remove all MCP tools from the shared tools array.
+   */
+  unregisterTools(
+    // biome-ignore lint/suspicious/noExplicitAny: Shared tools array holds heterogeneous types
+    toolsArray: ToolDefinition<any, any>[],
+  ): void {
+    if (this.registeredToolDefs.length === 0) return;
+
+    const mcpNames = new Set(this.registeredToolDefs.map((d) => d.name));
+    // Remove in-place by filtering
+    for (let i = toolsArray.length - 1; i >= 0; i--) {
+      if (mcpNames.has(toolsArray[i]!.name)) {
+        toolsArray.splice(i, 1);
+      }
+    }
+    this.registeredToolDefs = [];
+  }
+
+  /**
+   * Get the currently registered MCP ToolDefinitions.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: MCP tools have dynamic schemas
+  getRegisteredToolDefs(): ToolDefinition<any, any>[] {
+    return [...this.registeredToolDefs];
   }
 
   /**

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -2,6 +2,8 @@ import type { Tool } from 'ollama';
 import { z } from 'zod';
 import type { AgentMode } from '../modes';
 import { MODE_TOOLS } from '../modes';
+import { isMcpToolReadOnly } from '../mcp/types';
+import type { McpToolInfo } from '../mcp/types';
 import type { ToolContext, ToolDefinition, ToolResult } from '../types';
 import { editFileTool } from './edit-file';
 import { globTool } from './glob';
@@ -14,7 +16,7 @@ import { todoReadTool, todoWriteTool } from './todo';
 import { webFetchTool } from './web-fetch';
 import { writeFileTool } from './write-file';
 
-// All registered tools
+// All registered tools — mutable to allow MCP tool registration/unregistration
 // biome-ignore lint/suspicious/noExplicitAny: Tools array holds heterogeneous tool types with different schemas
 const tools: ToolDefinition<any, any>[] = [
   readFileTool,
@@ -29,6 +31,15 @@ const tools: ToolDefinition<any, any>[] = [
   taskTool,
   webFetchTool,
 ];
+
+/**
+ * Get the mutable tools array for MCP registration.
+ * McpManager.registerTools() and unregisterTools() operate on this array.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Tools array holds heterogeneous tool types
+export function getToolsArray(): ToolDefinition<any, any>[] {
+  return tools;
+}
 
 // Tool name constants for reference
 export const TOOL_NAMES = {
@@ -69,8 +80,13 @@ function toOllamaTool(def: ToolDefinition<any, any>): Tool {
   };
 }
 
-// Ollama-compatible tool schemas (all tools)
-export const ollamaTools: Tool[] = tools.map(toOllamaTool);
+/**
+ * Get Ollama-compatible tool schemas for all currently registered tools.
+ * Dynamic — includes MCP tools when registered.
+ */
+export function getOllamaTools(): Tool[] {
+  return tools.map(toOllamaTool);
+}
 
 /**
  * Get a tool definition by name.
@@ -100,13 +116,35 @@ export function getSafeParallelTools(): string[] {
 }
 
 /**
- * Get Ollama-compatible tools filtered by mode
- * Plan mode: read-only tools only
- * Build mode: all tools
+ * Check if a tool name is an MCP tool (mcp__server__tool pattern).
  */
-export function getToolsForMode(mode: AgentMode): Tool[] {
-  const allowedTools = MODE_TOOLS[mode];
-  return tools.filter((t) => allowedTools.includes(t.name)).map(toOllamaTool);
+function isMcpTool(name: string): boolean {
+  return name.startsWith('mcp__');
+}
+
+/**
+ * Get Ollama-compatible tools filtered by mode.
+ *
+ * Native tools: filtered by MODE_TOOLS[mode] (static list).
+ * MCP tools: build mode includes all, plan mode includes only readOnlyHint tools.
+ */
+export function getToolsForMode(
+  mode: AgentMode,
+  mcpTools?: McpToolInfo[],
+): Tool[] {
+  const allowedNative = MODE_TOOLS[mode];
+
+  return tools
+    .filter((t) => {
+      if (isMcpTool(t.name)) {
+        if (mode === 'build') return true;
+        // Plan mode: only include MCP tools with readOnlyHint
+        const mcpInfo = mcpTools?.find((m) => m.qualifiedName === t.name);
+        return mcpInfo ? isMcpToolReadOnly(mcpInfo) : false;
+      }
+      return allowedNative.includes(t.name);
+    })
+    .map(toOllamaTool);
 }
 
 // Execute a tool by name with validated args

--- a/tests/mock-mcp-server.ts
+++ b/tests/mock-mcp-server.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env bun
+/**
+ * Mock MCP server for integration testing.
+ *
+ * Provides three tools:
+ * - echo (read-only): returns the input text
+ * - add (read-only): adds two numbers
+ * - write_test (destructive): simulates a write operation
+ *
+ * Runs as a stdio MCP server. Launch with: bun tests/mock-mcp-server.ts
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+const server = new McpServer(
+  { name: 'mock-test-server', version: '1.0.0' },
+  {
+    capabilities: {
+      tools: {},
+    },
+  },
+);
+
+// echo — read-only tool that returns input text
+server.registerTool(
+  'echo',
+  {
+    description: 'Echoes the input text back',
+    inputSchema: { text: z.string().describe('Text to echo') },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  async ({ text }) => {
+    return { content: [{ type: 'text' as const, text }] };
+  },
+);
+
+// add — read-only tool that adds two numbers
+server.registerTool(
+  'add',
+  {
+    description: 'Adds two numbers together',
+    inputSchema: {
+      a: z.number().describe('First number'),
+      b: z.number().describe('Second number'),
+    },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  async ({ a, b }) => {
+    return { content: [{ type: 'text' as const, text: String(a + b) }] };
+  },
+);
+
+// write_test — destructive tool that simulates a write
+server.registerTool(
+  'write_test',
+  {
+    description: 'Simulates a write operation (test only)',
+    inputSchema: {
+      path: z.string().describe('File path to write'),
+      content: z.string().describe('Content to write'),
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+    },
+  },
+  async ({ path, content }) => {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Wrote ${content.length} chars to ${path}`,
+        },
+      ],
+    };
+  },
+);
+
+// Start the server on stdio
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/tests/test-mcp-execution.ts
+++ b/tests/test-mcp-execution.ts
@@ -1,0 +1,334 @@
+/**
+ * Integration tests for MCP tool registration and execution (Issue #90).
+ *
+ * Tests the full round-trip: config -> connect -> discover -> register -> call -> validate.
+ * Uses the mock MCP server (tests/mock-mcp-server.ts) via stdio transport.
+ *
+ * Run with: bun test ./tests/test-mcp-execution.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { resolve } from 'node:path';
+import { McpManager, createMcpToolDef } from '../src/agent/mcp/manager';
+import type { McpToolInfo } from '../src/agent/mcp/types';
+import {
+  executeTool,
+  getOllamaTools,
+  getToolDefinition,
+  getToolsArray,
+  getToolsForMode,
+} from '../src/agent/tools/index';
+
+const MOCK_SERVER_PATH = resolve(import.meta.dir, 'mock-mcp-server.ts');
+const SERVER_NAME = 'mock';
+
+// Increase timeout for server startup
+const TEST_TIMEOUT = 15_000;
+
+describe('MCP Tool Registration & Execution', () => {
+  let manager: McpManager;
+
+  beforeAll(async () => {
+    manager = new McpManager();
+    await manager.connectAll({
+      [SERVER_NAME]: {
+        type: 'local' as const,
+        command: ['bun', 'run', MOCK_SERVER_PATH],
+        environment: {},
+        enabled: true,
+        timeout: 10_000,
+        autoApprove: [],
+      },
+    });
+
+    // Register tools into the shared tools array
+    manager.registerTools(getToolsArray(), 50_000);
+  });
+
+  afterAll(async () => {
+    manager.unregisterTools(getToolsArray());
+    await manager.disconnectAll();
+  });
+
+  // --- Connection & Discovery ---
+
+  test('server connects successfully', () => {
+    const status = manager.getStatus();
+    const serverStatus = status.get(SERVER_NAME);
+    expect(serverStatus).toBeDefined();
+    expect(serverStatus!.status).toBe('connected');
+  });
+
+  test('discovers all three tools', () => {
+    const tools = manager.getAllTools();
+    const serverTools = tools.filter((t) => t.serverName === SERVER_NAME);
+    expect(serverTools.length).toBe(3);
+
+    const names = serverTools.map((t) => t.name).sort();
+    expect(names).toEqual(['add', 'echo', 'write_test']);
+  });
+
+  test('qualified names follow mcp__server__tool pattern', () => {
+    const tools = manager.getAllTools();
+    for (const tool of tools) {
+      expect(tool.qualifiedName).toBe(`mcp__${SERVER_NAME}__${tool.name}`);
+    }
+  });
+
+  test('annotations are preserved from server', () => {
+    const tools = manager.getAllTools();
+    const echo = tools.find((t) => t.name === 'echo');
+    expect(echo?.annotations?.readOnlyHint).toBe(true);
+    expect(echo?.annotations?.destructiveHint).toBe(false);
+
+    const writeTest = tools.find((t) => t.name === 'write_test');
+    expect(writeTest?.annotations?.destructiveHint).toBe(true);
+  });
+
+  // --- Tool Registration ---
+
+  test('MCP tools are registered in shared tools array', () => {
+    const echoDef = getToolDefinition('mcp__mock__echo');
+    expect(echoDef).toBeDefined();
+    expect(echoDef!.name).toBe('mcp__mock__echo');
+
+    const addDef = getToolDefinition('mcp__mock__add');
+    expect(addDef).toBeDefined();
+
+    const writeDef = getToolDefinition('mcp__mock__write_test');
+    expect(writeDef).toBeDefined();
+  });
+
+  test('MCP tools appear in getOllamaTools()', () => {
+    const ollamaTools = getOllamaTools();
+    const mcpToolNames = ollamaTools
+      .filter((t) => t.function?.name?.startsWith('mcp__'))
+      .map((t) => t.function.name!)
+      .sort();
+    expect(mcpToolNames).toEqual([
+      'mcp__mock__add',
+      'mcp__mock__echo',
+      'mcp__mock__write_test',
+    ]);
+  });
+
+  test('MCP tools have rawInputSchema set', () => {
+    const echoDef = getToolDefinition('mcp__mock__echo');
+    expect(echoDef!.rawInputSchema).toBeDefined();
+    expect(typeof echoDef!.rawInputSchema).toBe('object');
+  });
+
+  test('risk levels are mapped from annotations', () => {
+    const echoDef = getToolDefinition('mcp__mock__echo');
+    expect(echoDef!.risk).toBe('safe'); // readOnlyHint: true
+
+    const writeDef = getToolDefinition('mcp__mock__write_test');
+    expect(writeDef!.risk).toBe('high'); // destructiveHint: true
+  });
+
+  // --- Tool Execution ---
+
+  test(
+    'echo tool returns input text',
+    async () => {
+      const result = await executeTool('mcp__mock__echo', {
+        text: 'hello world',
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.output).toBe('hello world');
+    },
+    TEST_TIMEOUT,
+  );
+
+  test(
+    'add tool returns sum',
+    async () => {
+      const result = await executeTool('mcp__mock__add', { a: 3, b: 4 });
+      expect(result.error).toBeUndefined();
+      expect(result.output).toBe('7');
+    },
+    TEST_TIMEOUT,
+  );
+
+  test(
+    'write_test tool returns confirmation',
+    async () => {
+      const result = await executeTool('mcp__mock__write_test', {
+        path: '/tmp/test.txt',
+        content: 'hello',
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.output).toBe('Wrote 5 chars to /tmp/test.txt');
+    },
+    TEST_TIMEOUT,
+  );
+
+  // --- Mode Filtering ---
+
+  test('build mode includes all MCP tools', () => {
+    const mcpTools = manager.getAllTools();
+    const buildTools = getToolsForMode('build', mcpTools);
+    const mcpNames = buildTools
+      .filter((t) => t.function?.name?.startsWith('mcp__'))
+      .map((t) => t.function.name!)
+      .sort();
+    expect(mcpNames).toEqual([
+      'mcp__mock__add',
+      'mcp__mock__echo',
+      'mcp__mock__write_test',
+    ]);
+  });
+
+  test('plan mode includes only read-only MCP tools', () => {
+    const mcpTools = manager.getAllTools();
+    const planTools = getToolsForMode('plan', mcpTools);
+    const mcpNames = planTools
+      .filter((t) => t.function?.name?.startsWith('mcp__'))
+      .map((t) => t.function.name!)
+      .sort();
+    // echo and add are readOnlyHint: true, write_test is not
+    expect(mcpNames).toEqual(['mcp__mock__add', 'mcp__mock__echo']);
+  });
+
+  // --- Output Truncation ---
+
+  test(
+    'output is truncated at maxOutputChars',
+    async () => {
+      // Re-register with a tiny limit
+      manager.unregisterTools(getToolsArray());
+      manager.registerTools(getToolsArray(), 10);
+
+      const result = await executeTool('mcp__mock__echo', {
+        text: 'this is a long string that exceeds the limit',
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.output).toContain('[OUTPUT TRUNCATED');
+      expect(result.output.length).toBeLessThan(100); // 10 chars + truncation message
+
+      // Restore normal limit
+      manager.unregisterTools(getToolsArray());
+      manager.registerTools(getToolsArray(), 50_000);
+    },
+    TEST_TIMEOUT,
+  );
+
+  // --- Unregistration ---
+
+  test('unregisterTools removes MCP tools from array', () => {
+    const before = getToolsArray().length;
+    manager.unregisterTools(getToolsArray());
+
+    const after = getToolsArray().length;
+    expect(after).toBe(before - 3); // 3 MCP tools removed
+
+    // MCP tools are gone
+    expect(getToolDefinition('mcp__mock__echo')).toBeUndefined();
+    expect(getToolDefinition('mcp__mock__add')).toBeUndefined();
+    expect(getToolDefinition('mcp__mock__write_test')).toBeUndefined();
+
+    // Native tools still there
+    expect(getToolDefinition('read_file')).toBeDefined();
+
+    // Re-register for subsequent tests
+    manager.registerTools(getToolsArray(), 50_000);
+  });
+
+  // --- getRegisteredToolDefs ---
+
+  test('getRegisteredToolDefs returns current MCP tools', () => {
+    const defs = manager.getRegisteredToolDefs();
+    expect(defs.length).toBe(3);
+    const names = defs.map((d) => d.name).sort();
+    expect(names).toEqual([
+      'mcp__mock__add',
+      'mcp__mock__echo',
+      'mcp__mock__write_test',
+    ]);
+  });
+});
+
+// --- Unit tests for createMcpToolDef ---
+
+describe('createMcpToolDef', () => {
+  test('uses fromJSONSchema for valid schemas', () => {
+    const mockTool: McpToolInfo = {
+      name: 'test',
+      qualifiedName: 'mcp__srv__test',
+      description: 'A test tool',
+      inputSchema: {
+        type: 'object',
+        properties: { x: { type: 'string' } },
+        required: ['x'],
+      },
+      serverName: 'srv',
+      annotations: { readOnlyHint: true },
+    };
+
+    // We can't easily mock the client, but we can verify the ToolDefinition shape
+    const def = createMcpToolDef(
+      mockTool,
+      {} as any, // mock client — won't be called
+      10_000,
+      50_000,
+    );
+
+    expect(def.name).toBe('mcp__srv__test');
+    expect(def.description).toBe('A test tool');
+    expect(def.risk).toBe('safe');
+    expect(def.rawInputSchema).toEqual(mockTool.inputSchema);
+    expect(def.parameters).toBeDefined();
+
+    // Verify Zod validation works (fromJSONSchema succeeded)
+    const valid = def.parameters.safeParse({ x: 'hello' });
+    expect(valid.success).toBe(true);
+
+    const invalid = def.parameters.safeParse({ x: 123 });
+    expect(invalid.success).toBe(false);
+  });
+
+  test('falls back to z.any() for exotic schemas', () => {
+    const mockTool: McpToolInfo = {
+      name: 'exotic',
+      qualifiedName: 'mcp__srv__exotic',
+      description: 'Exotic schema tool',
+      inputSchema: {
+        // Use something that fromJSONSchema might not handle
+        type: 'object',
+        patternProperties: { '^S_': { type: 'string' } },
+      },
+      serverName: 'srv',
+    };
+
+    const def = createMcpToolDef(mockTool, {} as any, 10_000, 50_000);
+
+    expect(def.name).toBe('mcp__srv__exotic');
+    // Should still create a valid ToolDefinition even with fallback
+    expect(def.parameters).toBeDefined();
+
+    // z.any() accepts anything
+    const result = def.parameters.safeParse({ anything: 'goes' });
+    expect(result.success).toBe(true);
+  });
+
+  test('risk mapping from annotations', () => {
+    const makeDef = (annotations?: McpToolInfo['annotations']) => {
+      const tool: McpToolInfo = {
+        name: 't',
+        qualifiedName: 'mcp__s__t',
+        description: '',
+        inputSchema: { type: 'object' },
+        serverName: 's',
+        annotations,
+      };
+      return createMcpToolDef(tool, {} as any, 10_000, 50_000);
+    };
+
+    expect(makeDef(undefined).risk).toBe('medium');
+    expect(makeDef({ readOnlyHint: true }).risk).toBe('safe');
+    expect(makeDef({ destructiveHint: true }).risk).toBe('high');
+    expect(makeDef({ destructiveHint: true, readOnlyHint: true }).risk).toBe(
+      'high',
+    );
+  });
+});


### PR DESCRIPTION
## Issue #90: MCP Tool Registration & Execution

**Depends on:** #89 (merged)  
**Closes:** #90  
**Parent:** #27

### What

MCP tools discovered from external servers now appear as native `ToolDefinition` objects in the shared tools array. They can be called end-to-end through the existing `executeTool()` path — no separate dispatch.

### Changes

**`src/agent/mcp/manager.ts`**
- `createMcpToolDef()` — Converts `McpToolInfo` → `ToolDefinition` using `fromJSONSchema()` for real Zod validation of MCP tool parameters, with `z.any()` fallback for exotic schemas (logged as warning)
- `McpManager.registerTools()` — Creates `ToolDefinition` objects for all connected servers and pushes them into the shared tools array
- `McpManager.unregisterTools()` — Removes MCP tools from the shared array (reverse-iteration splice)
- `McpManager.getRegisteredToolDefs()` — Returns current MCP tool definitions
- Content serialization: text, image (placeholder), resource, with truncation at `maxOutputChars`

**`src/agent/tools/index.ts`**
- `getToolsArray()` — Exposes mutable tools array for MCP registration
- `getOllamaTools()` — Dynamic replacement for the removed static `ollamaTools` export
- `getToolsForMode()` — Now MCP-aware: build mode includes all MCP tools, plan mode includes only `readOnlyHint` tools
- Removed stale `ollamaTools` const (was a one-time snapshot that couldn't include dynamically registered MCP tools)

**`src/agent/mcp/index.ts`**
- Re-exports `createMcpToolDef`

**`tests/mock-mcp-server.ts`** (new)
- Stdio MCP server with 3 tools: `echo` (read-only), `add` (read-only), `write_test` (destructive)
- Uses MCP SDK `McpServer` + `StdioServerTransport`

**`tests/test-mcp-execution.ts`** (new)
- 19 tests covering: connection, discovery, registration, execution (echo/add/write_test), Ollama format, risk mapping, mode filtering, output truncation, unregistration, `createMcpToolDef` unit tests

### Design Decisions

- **Option D wiring**: MCP tools register directly into the existing tools array as `ToolDefinition` objects. No separate dispatch path.
- **`fromJSONSchema()` over `z.any()`**: Real validation by default. Fallback only when JSON Schema is too exotic (logged).
- **`rawInputSchema` bypass**: MCP tools store original JSON Schema; `toOllamaTool()` prefers it over lossy Zod→JSON-Schema round-trip.
- **Plan mode filtering**: Uses `McpToolInfo.annotations.readOnlyHint` — only read-only MCP tools in plan mode.

### Testing

```
68 pass, 0 fail across 3 files (mcp-types, env-expand, mcp-execution)
bunx tsc --noEmit — clean (no errors in src/ or tests/)
```

### What's Next

- **#91**: Safety & permissions integration (wire `mcpTools` to agent loop `getToolsForMode()` call)
- **#92**: Connection robustness (abort signal forwarding, dynamic re-registration on tool changes)
- **#93-#95**: TUI, approval UI, remote servers