### PR TITLE
feat(mcp): safety & permissions integration (#91)

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -86,6 +86,9 @@ export type RunAgentArgs = {
   /** Override the system prompt (used by subagents) */
   systemPromptOverride?: string;
 
+  /** MCP tool metadata for mode filtering (plan mode: readOnlyHint only) */
+  mcpTools?: import('./mcp/types').McpToolInfo[];
+
   /** Observation block from observational memory (injected into system prompt) */
   observationBlock?: string;
 
@@ -244,8 +247,8 @@ export async function runAgent(
   const mode = args.mode ?? DEFAULT_MODE;
   const temperature = args.temperature ?? 0.2;
 
-  // Get mode-specific tools and prompt
-  const modeTools = getToolsForMode(mode);
+  // Get mode-specific tools and prompt (pass mcpTools for plan mode filtering)
+  const modeTools = getToolsForMode(mode, args.mcpTools);
   const ctx = getDefaultContext(
     args.safetyConfig.projectRoot,
     args.configInstructions,

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -7,6 +7,7 @@
  */
 
 import type { CompactionConfig } from '../agent/compaction';
+import type { McpToolInfo } from '../agent/mcp/types';
 import type { SafetyConfig } from '../agent/safety/types';
 import type { AgentConfig, ToolsConfig } from '../agent/types';
 import type { MemoryConfig } from '../memory/types';
@@ -91,15 +92,32 @@ const AUTONOMY_BASELINES: Record<string, ToolPermissionMap> = {
 /**
  * Resolve the effective per-tool permission map.
  *
- * Starts from the autonomy level baseline, then applies
- * any explicit permission overrides from config.
+ * Starts from the autonomy level baseline, then registers MCP tool
+ * permissions (defaulting to 'ask' unless autonomous or autoApproved),
+ * then applies any explicit permission overrides from config.
  */
-export function resolvePermissions(config: ResolvedConfig): ToolPermissionMap {
+export function resolvePermissions(
+  config: ResolvedConfig,
+  mcpTools?: McpToolInfo[],
+): ToolPermissionMap {
   const baseline =
     AUTONOMY_BASELINES[config.autonomy] ?? AUTONOMY_BASELINES.cautious;
   const resolved = { ...baseline };
 
-  // Apply explicit overrides
+  // Register MCP tools with default permissions
+  if (mcpTools) {
+    const defaultPerm: PermissionValue =
+      config.autonomy === 'autonomous' ? 'allow' : 'ask';
+    for (const tool of mcpTools) {
+      // Server may not have a config entry (e.g., dynamically discovered) — defaults to 'ask'
+      const serverConfig = config.mcp[tool.serverName];
+      const isAutoApproved =
+        serverConfig?.autoApprove?.includes(tool.name) ?? false;
+      resolved[tool.qualifiedName] = isAutoApproved ? 'allow' : defaultPerm;
+    }
+  }
+
+  // Explicit overrides take highest priority
   for (const [tool, permission] of Object.entries(config.permissions)) {
     resolved[tool] = permission;
   }
@@ -139,12 +157,14 @@ export function extractCompactionConfig(
  *
  * Resolves autonomy level + permission overrides into a per-tool
  * permission map using the unified allow/ask/deny vocabulary.
+ * When mcpTools is provided, MCP tool permissions are included.
  */
 export function extractSafetyConfig(
   config: ResolvedConfig,
   projectRoot: string,
+  mcpTools?: McpToolInfo[],
 ): SafetyConfig {
-  const toolPermissions = resolvePermissions(config);
+  const toolPermissions = resolvePermissions(config, mcpTools);
 
   return {
     projectRoot,

--- a/src/tui/hooks/use-agent-submit.ts
+++ b/src/tui/hooks/use-agent-submit.ts
@@ -25,6 +25,7 @@ import {
   extractSafetyConfig,
   extractToolsConfig,
 } from '../../config/resolve';
+import type { McpToolInfo } from '../../agent/mcp/types';
 import type { ResolvedConfig } from '../../config/schema';
 import { checkMidLoopBuffering, processOMStep } from '../../memory/om';
 import { getTodos } from '../../session/todo';
@@ -71,6 +72,8 @@ export type UseAgentSubmitProps = {
   ) => void;
   /** Show a context info notification */
   setContextInfo?: (info: string | null) => void;
+  /** MCP tool metadata for permissions and mode filtering (populated by #93 TUI integration) */
+  mcpTools?: McpToolInfo[];
 };
 
 export type UseAgentSubmitReturn = {
@@ -231,10 +234,15 @@ export function useAgentSubmit(
       sessionId: session.id,
       signal: abortController.signal,
       config: extractAgentConfig(props.config),
-      safetyConfig: extractSafetyConfig(props.config, props.projectPath),
+      safetyConfig: extractSafetyConfig(
+        props.config,
+        props.projectPath,
+        props.mcpTools,
+      ),
       toolsConfig: extractToolsConfig(props.config),
       configInstructions: props.config.instructions,
       temperature: props.config.temperature,
+      mcpTools: props.mcpTools,
       observationBlock: omObservationBlock,
       continuationHint: omContinuationHint,
       onIterationComplete: (msgs, tokenInfo) => {

--- a/tests/test-mcp-permissions.ts
+++ b/tests/test-mcp-permissions.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for MCP tool permissions integration (Issue #91).
+ *
+ * Verifies that resolvePermissions() correctly handles MCP tools:
+ * - Default permissions based on autonomy level
+ * - autoApprove per-server overrides
+ * - Explicit permission overrides take highest priority
+ * - extractSafetyConfig() threads mcpTools through
+ *
+ * Run with: bun test ./tests/test-mcp-permissions.ts
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { McpToolInfo } from '../src/agent/mcp/types';
+import { extractSafetyConfig, resolvePermissions } from '../src/config/resolve';
+import { ConfigSchema } from '../src/config/schema';
+import type { ResolvedConfig } from '../src/config/schema';
+
+// Helper: create a minimal ResolvedConfig with overrides
+function makeConfig(
+  overrides: Partial<{
+    autonomy: string;
+    permissions: Record<string, string>;
+    mcp: Record<string, unknown>;
+  }>,
+): ResolvedConfig {
+  return ConfigSchema.parse({
+    autonomy: overrides.autonomy ?? 'cautious',
+    permissions: overrides.permissions ?? {},
+    mcp: overrides.mcp ?? {},
+  });
+}
+
+// Helper: create McpToolInfo
+function makeMcpTool(
+  serverName: string,
+  name: string,
+  readOnly = false,
+): McpToolInfo {
+  return {
+    name,
+    qualifiedName: `mcp__${serverName}__${name}`,
+    description: `Test tool ${name}`,
+    inputSchema: { type: 'object' },
+    serverName,
+    annotations: readOnly ? { readOnlyHint: true } : undefined,
+  };
+}
+
+// === resolvePermissions with MCP tools ===
+
+describe('resolvePermissions with MCP tools', () => {
+  const echoTool = makeMcpTool('testserver', 'echo', true);
+  const writeTool = makeMcpTool('testserver', 'write_file', false);
+  const otherTool = makeMcpTool('other', 'query', true);
+
+  test('MCP tools default to ask in cautious mode', () => {
+    const config = makeConfig({ autonomy: 'cautious' });
+    const perms = resolvePermissions(config, [echoTool, writeTool]);
+
+    expect(perms['mcp__testserver__echo']).toBe('ask');
+    expect(perms['mcp__testserver__write_file']).toBe('ask');
+  });
+
+  test('MCP tools default to ask in paranoid mode', () => {
+    const config = makeConfig({ autonomy: 'paranoid' });
+    const perms = resolvePermissions(config, [echoTool]);
+
+    expect(perms['mcp__testserver__echo']).toBe('ask');
+  });
+
+  test('MCP tools default to ask in balanced mode', () => {
+    const config = makeConfig({ autonomy: 'balanced' });
+    const perms = resolvePermissions(config, [echoTool]);
+
+    expect(perms['mcp__testserver__echo']).toBe('ask');
+  });
+
+  test('MCP tools default to allow in autonomous mode', () => {
+    const config = makeConfig({ autonomy: 'autonomous' });
+    const perms = resolvePermissions(config, [echoTool, writeTool]);
+
+    expect(perms['mcp__testserver__echo']).toBe('allow');
+    expect(perms['mcp__testserver__write_file']).toBe('allow');
+  });
+
+  test('autoApprove overrides default to allow', () => {
+    const config = makeConfig({
+      autonomy: 'cautious',
+      mcp: {
+        testserver: {
+          type: 'local',
+          command: ['echo'],
+          autoApprove: ['echo'],
+        },
+      },
+    });
+    const perms = resolvePermissions(config, [echoTool, writeTool]);
+
+    // echo is autoApproved
+    expect(perms['mcp__testserver__echo']).toBe('allow');
+    // write_file is not autoApproved — stays at default 'ask'
+    expect(perms['mcp__testserver__write_file']).toBe('ask');
+  });
+
+  test('autoApprove only affects matching server', () => {
+    const config = makeConfig({
+      autonomy: 'cautious',
+      mcp: {
+        testserver: {
+          type: 'local',
+          command: ['echo'],
+          autoApprove: ['echo'],
+        },
+      },
+    });
+    const perms = resolvePermissions(config, [echoTool, otherTool]);
+
+    // testserver echo is autoApproved
+    expect(perms['mcp__testserver__echo']).toBe('allow');
+    // other server's query is not
+    expect(perms['mcp__other__query']).toBe('ask');
+  });
+
+  test('explicit permission overrides take highest priority', () => {
+    const config = makeConfig({
+      autonomy: 'autonomous',
+      permissions: {
+        mcp__testserver__echo: 'deny',
+      },
+      mcp: {
+        testserver: {
+          type: 'local',
+          command: ['echo'],
+          autoApprove: ['echo'],
+        },
+      },
+    });
+    const perms = resolvePermissions(config, [echoTool]);
+
+    // Even though autonomous + autoApprove, explicit override wins
+    expect(perms['mcp__testserver__echo']).toBe('deny');
+  });
+
+  test('native tools unaffected by MCP tool registration', () => {
+    const config = makeConfig({ autonomy: 'cautious' });
+    const perms = resolvePermissions(config, [echoTool]);
+
+    // Native tools keep their baseline permissions
+    expect(perms['read_file']).toBe('allow');
+    expect(perms['write_file']).toBe('ask');
+    expect(perms['run_command']).toBe('ask');
+  });
+
+  test('no mcpTools arg works same as before', () => {
+    const config = makeConfig({ autonomy: 'cautious' });
+    const withMcp = resolvePermissions(config, []);
+    const withoutMcp = resolvePermissions(config);
+
+    // Same native tool permissions
+    expect(withMcp['read_file']).toBe('allow');
+    expect(withoutMcp['read_file']).toBe('allow');
+    expect(withMcp['write_file']).toBe('ask');
+    expect(withoutMcp['write_file']).toBe('ask');
+  });
+
+  test('undefined mcpTools works same as before', () => {
+    const config = makeConfig({ autonomy: 'cautious' });
+    const perms = resolvePermissions(config, undefined);
+
+    expect(perms['read_file']).toBe('allow');
+    expect(perms['write_file']).toBe('ask');
+    // No MCP tools in the map
+    expect(perms['mcp__testserver__echo']).toBeUndefined();
+  });
+
+  test('multiple servers register correctly', () => {
+    const config = makeConfig({
+      autonomy: 'cautious',
+      mcp: {
+        testserver: {
+          type: 'local',
+          command: ['echo'],
+          autoApprove: ['echo'],
+        },
+        other: {
+          type: 'local',
+          command: ['other'],
+          autoApprove: ['query'],
+        },
+      },
+    });
+    const perms = resolvePermissions(config, [echoTool, writeTool, otherTool]);
+
+    expect(perms['mcp__testserver__echo']).toBe('allow');
+    expect(perms['mcp__testserver__write_file']).toBe('ask');
+    expect(perms['mcp__other__query']).toBe('allow');
+  });
+
+  test('stale autoApprove entries do not create phantom permissions', () => {
+    const config = makeConfig({
+      autonomy: 'cautious',
+      mcp: {
+        testserver: {
+          type: 'local',
+          command: ['echo'],
+          autoApprove: ['nonexistent_tool', 'echo'],
+        },
+      },
+    });
+    // Only echo is in mcpTools — nonexistent_tool is not
+    const perms = resolvePermissions(config, [echoTool]);
+
+    expect(perms['mcp__testserver__echo']).toBe('allow');
+    // No phantom entry for the stale autoApprove
+    expect(perms['mcp__testserver__nonexistent_tool']).toBeUndefined();
+  });
+
+  test('MCP tool from unconfigured server defaults to ask', () => {
+    // Server not in config.mcp at all
+    const config = makeConfig({ autonomy: 'cautious' });
+    const perms = resolvePermissions(config, [otherTool]);
+
+    expect(perms['mcp__other__query']).toBe('ask');
+  });
+});
+
+// === extractSafetyConfig with MCP tools ===
+
+describe('extractSafetyConfig with MCP tools', () => {
+  const echoTool = makeMcpTool('testserver', 'echo', true);
+  const writeTool = makeMcpTool('testserver', 'write_file', false);
+
+  test('MCP tool permissions appear in safety config', () => {
+    const config = makeConfig({
+      autonomy: 'cautious',
+      mcp: {
+        testserver: {
+          type: 'local',
+          command: ['echo'],
+          autoApprove: ['echo'],
+        },
+      },
+    });
+    const safety = extractSafetyConfig(config, '/tmp/test', [
+      echoTool,
+      writeTool,
+    ]);
+
+    expect(safety.toolPermissions['mcp__testserver__echo']).toBe('allow');
+    expect(safety.toolPermissions['mcp__testserver__write_file']).toBe('ask');
+    // Native tools still present
+    expect(safety.toolPermissions['read_file']).toBe('allow');
+  });
+
+  test('without mcpTools, safety config has no MCP permissions', () => {
+    const config = makeConfig({ autonomy: 'cautious' });
+    const safety = extractSafetyConfig(config, '/tmp/test');
+
+    expect(safety.toolPermissions['mcp__testserver__echo']).toBeUndefined();
+    expect(safety.toolPermissions['read_file']).toBe('allow');
+  });
+
+  test('autonomy level flows through to MCP permissions', () => {
+    const config = makeConfig({ autonomy: 'autonomous' });
+    const safety = extractSafetyConfig(config, '/tmp/test', [echoTool]);
+
+    expect(safety.toolPermissions['mcp__testserver__echo']).toBe('allow');
+    expect(safety.autonomyLevel).toBe('autonomous');
+  });
+});


### PR DESCRIPTION
## Issue #91: MCP Safety & Permissions Integration

**Depends on:** #90 (merged as PR #97)
**Closes:** #91
**Parent:** #27

### What

MCP tools now participate in the autonomy/permissions system. Permission resolution follows a three-tier priority model: autonomy baseline -> MCP defaults (with autoApprove) -> explicit overrides.

### Changes

**`src/config/resolve.ts`**
- `resolvePermissions(config, mcpTools?)` — MCP tools default to `'ask'` in all autonomy levels except `autonomous` (`'allow'`). `autoApprove` per-server config overrides to `'allow'`. Explicit permission overrides take highest priority.
- `extractSafetyConfig(config, projectRoot, mcpTools?)` — threads `mcpTools` to `resolvePermissions()`

**`src/agent/index.ts`**
- `RunAgentArgs.mcpTools` — optional MCP tool metadata for plan mode filtering
- `getToolsForMode(mode, args.mcpTools)` — wired to pass MCP metadata

**`src/tui/hooks/use-agent-submit.ts`**
- `UseAgentSubmitProps.mcpTools` — optional prop (populated by #93 TUI integration)
- Threads `mcpTools` to both `extractSafetyConfig()` and `runAgent()`

**`tests/test-mcp-permissions.ts`** (new)
- 16 tests: all autonomy levels, autoApprove scoping per-server, explicit override priority, native tool non-interference, stale autoApprove entries, unconfigured server defaults, extractSafetyConfig pass-through

### Design Decisions

- **Three-tier priority:** autonomy baseline (lowest) -> MCP autoApprove (middle) -> explicit permission overrides (highest)
- **Default 'ask' for MCP tools:** Conservative — external tools should require confirmation unless explicitly approved
- **Optional throughout:** All `mcpTools` params are optional. When omitted, behavior is identical to before (fully backward compatible)
- **TUI wiring deferred:** `UseAgentSubmitProps.mcpTools` is added but not yet populated — #93 will connect McpManager to the TUI

### Testing

```
82 pass, 0 fail across 4 MCP test files
bunx tsc --noEmit — clean
```

### What's Next

- **#92**: Connection robustness (abort signal, auto-reconnect, dynamic re-registration)
- **#93**: TUI integration (wire McpManager, populate mcpTools prop)
- **#94**: Approval UI
- **#95**: Remote/SSE servers