### PR TITLE
feat(mcp): TUI integration — status bar, /mcp command, tool display, toasts (#93)

### DIFF
--- a/src/tui/components/index.ts
+++ b/src/tui/components/index.ts
@@ -30,6 +30,10 @@ export {
 // Input components
 export { InputBox, type InputBoxProps } from './input-box';
 export { KeyboardShortcutsModal } from './keyboard-shortcuts-modal';
+export {
+  McpStatusModal,
+  type McpStatusModalProps,
+} from './mcp-status-modal';
 export { Modal } from './modal';
 export { SessionPicker } from './session-picker';
 // Layout components

--- a/src/tui/components/input-box.tsx
+++ b/src/tui/components/input-box.tsx
@@ -1,6 +1,7 @@
 import { RGBA, SyntaxStyle, type TextareaRenderable } from '@opentui/core';
 import { createEffect } from 'solid-js';
 import type { AgentMode } from '../../agent/modes';
+import type { McpStatusMap } from '../../agent/mcp/types';
 import { useTheme } from '../../design';
 import type { Status } from '../types';
 import { StatusBar } from './status-bar';
@@ -29,6 +30,10 @@ export type InputBoxProps = {
   disabled?: boolean;
   /** When true, prevents submit on Enter (e.g., when file picker is open) */
   suppressSubmit?: boolean;
+  /** MCP server status map for status bar display */
+  mcpStatus?: McpStatusMap;
+  /** Whether MCP is still connecting on startup */
+  mcpConnecting?: boolean;
 };
 
 /** Regex to find @mentions: @ at start or after whitespace, followed by non-whitespace */
@@ -126,7 +131,13 @@ export function InputBox(props: InputBoxProps) {
         onSubmit={handleSubmit}
         onContentChange={updateMentionHighlights}
       />
-      <StatusBar model={props.model} status={props.status} mode={props.mode} />
+      <StatusBar
+        model={props.model}
+        status={props.status}
+        mode={props.mode}
+        mcpStatus={props.mcpStatus}
+        mcpConnecting={props.mcpConnecting}
+      />
     </box>
   );
 }

--- a/src/tui/components/mcp-status-modal.tsx
+++ b/src/tui/components/mcp-status-modal.tsx
@@ -1,0 +1,135 @@
+/**
+ * Modal displaying MCP server status, tools, and debug info.
+ * Shown via the /mcp slash command.
+ */
+
+import { For, Show } from 'solid-js';
+import type { McpManager } from '../../agent/mcp';
+import type { McpStatusMap } from '../../agent/mcp/types';
+import { useTheme } from '../../design';
+import { Modal } from './modal';
+
+export type McpStatusModalProps = {
+  /** Current status map for all servers */
+  mcpStatus: McpStatusMap;
+  /** McpManager instance for accessing server tools and stderr */
+  manager: McpManager;
+  /** Close handler */
+  onClose: () => void;
+};
+
+/** Status label with color */
+function statusLabel(
+  status: string,
+  tokens: {
+    success: string;
+    warning: string;
+    error: string;
+    textMuted: string;
+  },
+): { text: string; color: string } {
+  switch (status) {
+    case 'connected':
+      return { text: 'connected', color: tokens.success };
+    case 'connecting':
+      return { text: 'connecting...', color: tokens.warning };
+    case 'error':
+      return { text: 'error', color: tokens.error };
+    case 'disconnected':
+      return { text: 'disconnected', color: tokens.textMuted };
+    default:
+      return { text: status, color: tokens.textMuted };
+  }
+}
+
+export function McpStatusModal(props: McpStatusModalProps) {
+  const { tokens } = useTheme();
+
+  const serverEntries = () => Array.from(props.mcpStatus.entries());
+
+  return (
+    <Modal title="MCP Servers" onClose={props.onClose} size="large">
+      <Show
+        when={serverEntries().length > 0}
+        fallback={
+          <text style={{ fg: tokens.textMuted }}>
+            No MCP servers configured. Add servers to your config under the
+            "mcp" key.
+          </text>
+        }
+      >
+        <For each={serverEntries()}>
+          {([name, info]) => {
+            const label = statusLabel(info.status, tokens);
+            const tools = props.manager.getServerTools(name);
+            const stderr = props.manager.getServerStderr(name);
+
+            return (
+              <box flexDirection="column" marginBottom={1}>
+                {/* Server header: name + status */}
+                <box flexDirection="row">
+                  <text style={{ fg: tokens.primaryBase }}>
+                    <b>{name}</b>
+                  </text>
+                  <text style={{ fg: label.color }}> [{label.text}]</text>
+                  <Show when={info.status === 'connected'}>
+                    <text style={{ fg: tokens.textMuted }}>
+                      {' '}
+                      ({info.toolCount} tool
+                      {info.toolCount !== 1 ? 's' : ''})
+                    </text>
+                  </Show>
+                </box>
+
+                {/* Error message */}
+                <Show when={info.error}>
+                  {(error: () => string) => (
+                    <text style={{ fg: tokens.error, marginLeft: 2 }}>
+                      Error: {error()}
+                    </text>
+                  )}
+                </Show>
+
+                {/* Tool list */}
+                <Show when={tools.length > 0}>
+                  <box marginLeft={2} marginTop={0}>
+                    <text style={{ fg: tokens.textMuted }}>Tools:</text>
+                  </box>
+                  <For each={tools}>
+                    {(tool) => (
+                      <text style={{ fg: tokens.textBase, marginLeft: 4 }}>
+                        - {tool.name}
+                        <span style={{ fg: tokens.textMuted }}>
+                          {tool.description
+                            ? ` — ${tool.description.slice(0, 60)}${tool.description.length > 60 ? '...' : ''}`
+                            : ''}
+                        </span>
+                      </text>
+                    )}
+                  </For>
+                </Show>
+
+                {/* Stderr tail */}
+                <Show when={stderr.length > 0}>
+                  <box marginLeft={2} marginTop={1}>
+                    <text style={{ fg: tokens.textMuted }}>
+                      Recent stderr ({stderr.length} line
+                      {stderr.length !== 1 ? 's' : ''}):
+                    </text>
+                  </box>
+                  <For each={stderr.slice(-5)}>
+                    {(line) => (
+                      <text style={{ fg: tokens.warning, marginLeft: 4 }}>
+                        {line.slice(0, 120)}
+                      </text>
+                    )}
+                  </For>
+                </Show>
+              </box>
+            );
+          }}
+        </For>
+      </Show>
+    </Modal>
+  );
+}

--- a/src/tui/components/status-bar.tsx
+++ b/src/tui/components/status-bar.tsx
@@ -1,12 +1,18 @@
 import { createMemo, mergeProps, Show } from 'solid-js';
 import type { AgentMode } from '../../agent/modes';
+import type { McpStatusMap } from '../../agent/mcp/types';
 import { useTheme } from '../../design';
 import type { Status } from '../types';
+import { formatMcpStatus } from '../utils/mcp-display';
 
 export type StatusBarProps = {
   model: string;
   status: Status;
   mode?: AgentMode;
+  /** MCP server status map (optional — omitted when no MCP servers configured) */
+  mcpStatus?: McpStatusMap;
+  /** Whether MCP is still connecting on startup */
+  mcpConnecting?: boolean;
 };
 
 export function StatusBar(rawProps: StatusBarProps) {
@@ -17,6 +23,10 @@ export function StatusBar(rawProps: StatusBarProps) {
     plan: tokens.info,
     build: tokens.success,
   }));
+
+  const mcpText = createMemo(() =>
+    formatMcpStatus(props.mcpStatus, props.mcpConnecting),
+  );
 
   return (
     <box
@@ -33,6 +43,11 @@ export function StatusBar(rawProps: StatusBarProps) {
         <text style={{ fg: tokens.textMuted }}> • {props.model}</text>
         <Show when={props.status === 'thinking'}>
           <text style={{ fg: tokens.primaryBase }}> • Thinking...</text>
+        </Show>
+        <Show when={mcpText()}>
+          {(text: () => string) => (
+            <text style={{ fg: tokens.textMuted }}> • {text()}</text>
+          )}
         </Show>
       </box>
       <box style={{ flexDirection: 'row' }}>

--- a/src/tui/components/tool-message.tsx
+++ b/src/tui/components/tool-message.tsx
@@ -13,6 +13,7 @@ import { useTheme } from '../../design';
 import type { SemanticTokens } from '../../design/tokens';
 import { FocusLayer, useScopedKeyboard } from '../keyboard';
 import type { ToolDisplayMessage, ToolMetadata, ToolState } from '../types';
+import { getToolDisplayName } from '../utils/mcp-display';
 import { DiffView } from './diff-view';
 
 export type ToolMessageProps = {
@@ -32,6 +33,17 @@ const EXPANDABLE_TOOLS = ['read_file', 'glob', 'grep', 'list_dir'];
  * Format the tool header based on tool type and arguments.
  */
 function formatToolHeader(name: string, args: Record<string, unknown>): string {
+  // MCP tools: no special header formatting, just show args summary
+  if (name.startsWith('mcp__')) {
+    // Show first string arg as a brief hint, if any
+    for (const value of Object.values(args)) {
+      if (typeof value === 'string' && value.length > 0) {
+        return value.length > 60 ? `${value.slice(0, 60)}...` : value;
+      }
+    }
+    return '';
+  }
+
   switch (name) {
     case 'read_file':
       return String(args.path ?? '');
@@ -314,6 +326,7 @@ function ConfirmingView(props: {
 
   const preview = props.message.state.preview;
   const header = formatToolHeader(props.message.name, props.message.args);
+  const displayName = getToolDisplayName(props.message.name);
 
   return (
     <box
@@ -328,9 +341,7 @@ function ConfirmingView(props: {
       {/* Header */}
       <box style={{ flexDirection: 'row' }}>
         <text style={{ fg: props.tokens.warning }}>{'\u25B3'} </text>
-        <text style={{ fg: props.tokens.primaryBase }}>
-          {props.message.name}
-        </text>
+        <text style={{ fg: props.tokens.primaryBase }}>{displayName}</text>
         <Show when={header}>
           <text style={{ fg: props.tokens.textMuted }}> {header}</text>
         </Show>
@@ -547,7 +558,11 @@ function ExpandableTool(props: {
   const icon = getStatusIcon(props.message.state);
   const iconColor = getStatusColor(props.message.state, props.tokens);
   const header = formatToolHeader(props.message.name, props.message.args);
+  const displayName = getToolDisplayName(props.message.name);
   const isExpandable = EXPANDABLE_TOOLS.includes(props.message.name);
+  // MCP tools are always expandable (they aren't in the native EXPANDABLE_TOOLS list)
+  const isMcp = props.message.name.startsWith('mcp__');
+  const canExpand = isExpandable || isMcp;
 
   const outputSummary = formatCompletedOutput(
     props.message.name,
@@ -559,7 +574,7 @@ function ExpandableTool(props: {
     <Show
       when={
         props.expanded &&
-        isExpandable &&
+        canExpand &&
         props.message.state.status === 'completed' &&
         props.message.state.output
       }
@@ -567,12 +582,12 @@ function ExpandableTool(props: {
         <InlineTool
           icon={icon}
           iconColor={iconColor}
-          name={props.message.name}
+          name={displayName}
           header={header}
           suffix={
             outputSummary
-              ? `(${outputSummary})${isExpandable ? ' [ctrl+e to expand]' : ''}`
-              : isExpandable
+              ? `(${outputSummary})${canExpand ? ' [ctrl+e to expand]' : ''}`
+              : canExpand
                 ? '[ctrl+e to expand]'
                 : undefined
           }
@@ -583,7 +598,7 @@ function ExpandableTool(props: {
       <BlockTool
         icon={icon}
         iconColor={iconColor}
-        name={props.message.name}
+        name={displayName}
         header={header}
         tokens={props.tokens}
       >
@@ -606,6 +621,7 @@ export function ToolMessage(props: ToolMessageProps) {
   const icon = getStatusIcon(props.message.state);
   const iconColor = getStatusColor(props.message.state, tokens);
   const header = formatToolHeader(props.message.name, props.message.args);
+  const displayName = getToolDisplayName(props.message.name);
 
   // State-based rendering
   // NOTE: The switch runs once per ToolMessage creation. This is fine because
@@ -620,7 +636,7 @@ export function ToolMessage(props: ToolMessageProps) {
         <InlineTool
           icon={icon}
           iconColor={iconColor}
-          name={props.message.name}
+          name={displayName}
           header={header}
           suffix={
             props.message.state.status === 'executing' ? '(running...)' : ''
@@ -651,7 +667,7 @@ export function ToolMessage(props: ToolMessageProps) {
         return <CommandCompleted message={props.message} tokens={tokens} />;
       }
 
-      // Read-only tools: support expand/collapse via reactive <Show>
+      // MCP tools and read-only native tools: use expand/collapse
       return (
         <ExpandableTool
           message={props.message}
@@ -666,7 +682,7 @@ export function ToolMessage(props: ToolMessageProps) {
         <BlockTool
           icon={icon}
           iconColor={iconColor}
-          name={props.message.name}
+          name={displayName}
           header={header}
           tokens={tokens}
         >
@@ -679,7 +695,7 @@ export function ToolMessage(props: ToolMessageProps) {
         <InlineTool
           icon={icon}
           iconColor={iconColor}
-          name={props.message.name}
+          name={displayName}
           header={header}
           suffix={
             props.message.state.reason
@@ -696,7 +712,7 @@ export function ToolMessage(props: ToolMessageProps) {
         <InlineTool
           icon={icon}
           iconColor={iconColor}
-          name={props.message.name}
+          name={displayName}
           header={header}
           suffix={`(blocked: ${props.message.state.reason})`}
           dimmed

--- a/src/tui/hooks/index.ts
+++ b/src/tui/hooks/index.ts
@@ -32,6 +32,11 @@ export {
   useMessageStore,
 } from './use-message-store';
 export {
+  type UseMcpProps,
+  type UseMcpReturn,
+  useMcp,
+} from './use-mcp';
+export {
   type UseSessionProps,
   type UseSessionReturn,
   useSession,

--- a/src/tui/hooks/use-agent-submit.ts
+++ b/src/tui/hooks/use-agent-submit.ts
@@ -72,8 +72,8 @@ export type UseAgentSubmitProps = {
   ) => void;
   /** Show a context info notification */
   setContextInfo?: (info: string | null) => void;
-  /** MCP tool metadata for permissions and mode filtering (populated by #93 TUI integration) */
-  mcpTools?: McpToolInfo[];
+  /** MCP tool metadata for permissions and mode filtering (signal accessor for reactivity) */
+  mcpTools?: () => McpToolInfo[];
 };
 
 export type UseAgentSubmitReturn = {
@@ -237,12 +237,12 @@ export function useAgentSubmit(
       safetyConfig: extractSafetyConfig(
         props.config,
         props.projectPath,
-        props.mcpTools,
+        props.mcpTools?.(),
       ),
       toolsConfig: extractToolsConfig(props.config),
       configInstructions: props.config.instructions,
       temperature: props.config.temperature,
-      mcpTools: props.mcpTools,
+      mcpTools: props.mcpTools?.(),
       observationBlock: omObservationBlock,
       continuationHint: omContinuationHint,
       onIterationComplete: (msgs, tokenInfo) => {

--- a/src/tui/hooks/use-command-menu.ts
+++ b/src/tui/hooks/use-command-menu.ts
@@ -20,6 +20,7 @@ export type UseCommandMenuProps = {
     handleForget: (n: number) => void;
     handleInit: (args?: string) => void;
     handleConfig: () => void;
+    handleMcp: () => void;
     setShowSessionPicker: Setter<boolean>;
     setShowThemePicker: Setter<boolean>;
   };
@@ -136,6 +137,14 @@ export function useCommandMenu(
       description: 'Show active configuration and sources',
       action: () => {
         props.handlers.handleConfig();
+        props.getTextareaRef()?.setText('');
+      },
+    },
+    {
+      name: 'mcp',
+      description: 'Show MCP server status and tools',
+      action: () => {
+        props.handlers.handleMcp();
         props.getTextareaRef()?.setText('');
       },
     },

--- a/src/tui/hooks/use-mcp.ts
+++ b/src/tui/hooks/use-mcp.ts
@@ -1,0 +1,119 @@
+/**
+ * Hook for MCP (Model Context Protocol) integration into the TUI.
+ *
+ * Manages the McpManager lifecycle:
+ * - Creates manager and connects servers from config on mount
+ * - Exposes reactive signals for status map and tool list
+ * - Registers/unregisters MCP tools in the shared tools array
+ * - Fires toast callbacks on connect/disconnect/tools-changed events
+ * - Cleans up (disconnects all servers) on unmount
+ */
+
+import { createSignal, onCleanup, onMount } from 'solid-js';
+import { McpManager } from '../../agent/mcp';
+import type { McpStatusMap, McpToolInfo } from '../../agent/mcp/types';
+import { getToolsArray } from '../../agent/tools';
+import type { ResolvedConfig } from '../../config/schema';
+
+export type UseMcpProps = {
+  /** Resolved app config (mcp field has server configs) */
+  config: ResolvedConfig;
+  /** Callback to show a toast message */
+  onToast?: (message: string) => void;
+};
+
+export type UseMcpReturn = {
+  /** Reactive MCP status map (server name -> status/toolCount/error) */
+  mcpStatus: () => McpStatusMap;
+  /** Reactive list of all MCP tool metadata (for permissions/mode filtering) */
+  mcpTools: () => McpToolInfo[];
+  /** The McpManager instance (for /mcp command access to stderr, etc.) */
+  manager: McpManager;
+  /** Whether initial connection is still in progress */
+  connecting: () => boolean;
+};
+
+export function useMcp(props: UseMcpProps): UseMcpReturn {
+  const manager = new McpManager();
+
+  const [mcpStatus, setMcpStatus] = createSignal<McpStatusMap>(new Map());
+  const [mcpTools, setMcpTools] = createSignal<McpToolInfo[]>([]);
+  const [connecting, setConnecting] = createSignal(false);
+
+  /** Snapshot current status from manager into signal */
+  const refreshStatus = () => {
+    setMcpStatus(manager.getStatus());
+  };
+
+  /** Max output chars for MCP tool truncation */
+  const maxOutputChars = props.config.tools.mcp.maxOutputChars;
+
+  // Track unsubscribe function for cleanup
+  let unsubscribe: (() => void) | undefined;
+
+  // Cleanup unconditionally — safe even if no servers were connected (#4 review)
+  onCleanup(() => {
+    unsubscribe?.();
+    manager.unregisterTools(getToolsArray());
+    void manager.disconnectAll();
+  });
+
+  onMount(() => {
+    const servers = props.config.mcp;
+    const serverNames = Object.keys(servers).filter(
+      (name) => servers[name]?.enabled !== false,
+    );
+
+    // Nothing to do if no MCP servers configured
+    if (serverNames.length === 0) return;
+
+    setConnecting(true);
+
+    // Listen for tool list changes (reconnects, dynamic tool updates)
+    unsubscribe = manager.onToolsChanged((tools) => {
+      setMcpTools(tools);
+      refreshStatus();
+
+      // Re-register tools in the shared array with fresh definitions
+      manager.registerTools(getToolsArray(), maxOutputChars);
+    });
+
+    // Connect all servers, then register tools and update signals
+    void manager
+      .connectAll(servers)
+      .then(() => {
+        const tools = manager.getAllTools();
+        setMcpTools(tools);
+        refreshStatus();
+        setConnecting(false);
+
+        // Register MCP tools into the shared tools array
+        manager.registerTools(getToolsArray(), maxOutputChars);
+
+        // Fire toast for each connected server
+        const status = manager.getStatus();
+        for (const [name, info] of status) {
+          if (info.status === 'connected') {
+            props.onToast?.(
+              `MCP: ${name} connected (${info.toolCount} tool${info.toolCount !== 1 ? 's' : ''})`,
+            );
+          } else if (info.status === 'error') {
+            props.onToast?.(`MCP: ${name} failed to connect`);
+          }
+        }
+      })
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        props.onToast?.(`MCP: initialization failed — ${message}`);
+        setConnecting(false);
+        refreshStatus();
+      });
+  });
+
+  return {
+    mcpStatus,
+    mcpTools,
+    manager,
+    connecting,
+  };
+}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -21,6 +21,7 @@ import {
   FilePicker,
   InputBox,
   KeyboardShortcutsModal,
+  McpStatusModal,
   SessionPicker,
   SidePanel,
   ThemePicker,
@@ -34,6 +35,7 @@ import {
   useCommandMenu,
   useFilePicker,
   useKeyboardShortcuts,
+  useMcp,
   useSession,
 } from './hooks';
 import { useMessageStore } from './hooks/use-message-store';
@@ -77,6 +79,13 @@ function AppContent(props: AppProps) {
   let textareaRef: TextareaRenderable | undefined;
   const [toast, setToast] = createSignal<string | null>(null);
   const [showConfigModal, setShowConfigModal] = createSignal(false);
+  const [showMcpModal, setShowMcpModal] = createSignal(false);
+
+  // MCP hook — connects servers, registers tools, provides reactive status
+  const mcp = useMcp({
+    config: props.config,
+    onToast: (message) => setToast(message),
+  });
 
   // Getter for textarea ref
   const getTextareaRef = () => textareaRef;
@@ -114,6 +123,7 @@ function AppContent(props: AppProps) {
     setSidebarTodos: session.setSidebarTodos,
     updateRealTokenCounts: context.updateRealTokenCounts,
     setContextInfo: context.setContextInfo,
+    mcpTools: mcp.mcpTools,
   });
 
   // Status getter for InputBox
@@ -138,6 +148,7 @@ function AppContent(props: AppProps) {
       handleForget: context.handleForget,
       handleInit,
       handleConfig: () => setShowConfigModal(true),
+      handleMcp: () => setShowMcpModal(true),
       setShowSessionPicker: session.setShowSessionPicker,
       setShowThemePicker: session.setShowThemePicker,
     },
@@ -187,6 +198,14 @@ function AppContent(props: AppProps) {
               layers={configLayers}
               warnings={configWarnings}
               onClose={() => setShowConfigModal(false)}
+            />
+          </Show>
+
+          <Show when={showMcpModal()}>
+            <McpStatusModal
+              mcpStatus={mcp.mcpStatus()}
+              manager={mcp.manager}
+              onClose={() => setShowMcpModal(false)}
             />
           </Show>
 
@@ -280,6 +299,8 @@ function AppContent(props: AppProps) {
                 session.showSessionPicker() || session.showThemePicker()
               }
               suppressSubmit={filePicker.showFilePicker()}
+              mcpStatus={mcp.mcpStatus()}
+              mcpConnecting={mcp.connecting()}
             />
           </box>
 
@@ -318,6 +339,14 @@ function AppContent(props: AppProps) {
             layers={configLayers}
             warnings={configWarnings}
             onClose={() => setShowConfigModal(false)}
+          />
+        </Show>
+
+        <Show when={showMcpModal()}>
+          <McpStatusModal
+            mcpStatus={mcp.mcpStatus()}
+            manager={mcp.manager}
+            onClose={() => setShowMcpModal(false)}
           />
         </Show>
 
@@ -478,6 +507,8 @@ function AppContent(props: AppProps) {
                 session.showThemePicker()
               }
               suppressSubmit={filePicker.showFilePicker()}
+              mcpStatus={mcp.mcpStatus()}
+              mcpConnecting={mcp.connecting()}
             />
           </box>
         </box>

--- a/src/tui/utils/mcp-display.ts
+++ b/src/tui/utils/mcp-display.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure utility functions for MCP display in the TUI.
+ * Extracted from components for testability.
+ */
+
+import type { McpStatusMap } from '../../agent/mcp/types';
+
+/**
+ * Parse MCP qualified tool name (mcp__server__tool) into display parts.
+ * Returns null if not an MCP tool name.
+ */
+export function parseMcpToolName(name: string): {
+  displayName: string;
+  serverName: string;
+  toolName: string;
+} | null {
+  const match = name.match(/^mcp__([^_]+(?:_[^_]+)*)__(.+)$/);
+  if (!match?.[1] || !match[2]) return null;
+  return {
+    displayName: `${match[1]} > ${match[2]}`,
+    serverName: match[1],
+    toolName: match[2],
+  };
+}
+
+/**
+ * Get the display name for a tool, formatting MCP tools as "server > tool".
+ * Native tools pass through unchanged.
+ */
+export function getToolDisplayName(name: string): string {
+  const mcp = parseMcpToolName(name);
+  return mcp ? mcp.displayName : name;
+}
+
+/**
+ * Format MCP status map for display in the status bar.
+ *
+ * Examples:
+ *   "MCP: github(3) context7(2)"
+ *   "MCP: github(err) context7(2)"
+ *   "MCP: connecting..."
+ *   null (no servers configured)
+ */
+export function formatMcpStatus(
+  status: McpStatusMap | undefined,
+  connecting: boolean | undefined,
+): string | null {
+  if (!status || status.size === 0) return null;
+
+  if (connecting) return 'MCP: connecting...';
+
+  const parts: string[] = [];
+  for (const [name, info] of status) {
+    if (info.status === 'error') {
+      parts.push(`${name}(err)`);
+    } else if (info.status === 'connecting') {
+      parts.push(`${name}(...)`);
+    } else if (info.status === 'connected') {
+      parts.push(`${name}(${info.toolCount})`);
+    } else {
+      // disconnected
+      parts.push(`${name}(off)`);
+    }
+  }
+
+  return parts.length > 0 ? `MCP: ${parts.join(' ')}` : null;
+}

--- a/tests/test-mcp-tui.ts
+++ b/tests/test-mcp-tui.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for MCP TUI display utilities (Issue #93).
+ *
+ * Tests pure functions: parseMcpToolName, getToolDisplayName, formatMcpStatus.
+ * No SolidJS/OpenTUI dependency — these are plain TS functions.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { McpStatusMap } from '../src/agent/mcp/types';
+import {
+  formatMcpStatus,
+  getToolDisplayName,
+  parseMcpToolName,
+} from '../src/tui/utils/mcp-display';
+
+// --- parseMcpToolName ---
+
+describe('parseMcpToolName', () => {
+  test('parses simple mcp__server__tool', () => {
+    const result = parseMcpToolName('mcp__github__list_repos');
+    expect(result).toEqual({
+      displayName: 'github > list_repos',
+      serverName: 'github',
+      toolName: 'list_repos',
+    });
+  });
+
+  test('parses server name with single underscore', () => {
+    const result = parseMcpToolName('mcp__my_server__do_thing');
+    expect(result).toEqual({
+      displayName: 'my_server > do_thing',
+      serverName: 'my_server',
+      toolName: 'do_thing',
+    });
+  });
+
+  test('returns null for native tool names', () => {
+    expect(parseMcpToolName('read_file')).toBeNull();
+    expect(parseMcpToolName('run_command')).toBeNull();
+    expect(parseMcpToolName('edit_file')).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(parseMcpToolName('')).toBeNull();
+  });
+
+  test('returns null for partial mcp__ prefix without tool', () => {
+    expect(parseMcpToolName('mcp__server')).toBeNull();
+  });
+
+  test('parses tool name with underscores', () => {
+    const result = parseMcpToolName('mcp__context7__resolve_library_id');
+    expect(result).toEqual({
+      displayName: 'context7 > resolve_library_id',
+      serverName: 'context7',
+      toolName: 'resolve_library_id',
+    });
+  });
+});
+
+// --- getToolDisplayName ---
+
+describe('getToolDisplayName', () => {
+  test('formats MCP tool as server > tool', () => {
+    expect(getToolDisplayName('mcp__github__list_repos')).toBe(
+      'github > list_repos',
+    );
+  });
+
+  test('passes through native tool names unchanged', () => {
+    expect(getToolDisplayName('read_file')).toBe('read_file');
+    expect(getToolDisplayName('run_command')).toBe('run_command');
+    expect(getToolDisplayName('glob')).toBe('glob');
+  });
+});
+
+// --- formatMcpStatus ---
+
+describe('formatMcpStatus', () => {
+  test('returns null for undefined status', () => {
+    expect(formatMcpStatus(undefined, false)).toBeNull();
+  });
+
+  test('returns null for empty status map', () => {
+    const status: McpStatusMap = new Map();
+    expect(formatMcpStatus(status, false)).toBeNull();
+  });
+
+  test('returns connecting message when connecting flag is true', () => {
+    const status: McpStatusMap = new Map([
+      ['github', { status: 'connecting', toolCount: 0 }],
+    ]);
+    expect(formatMcpStatus(status, true)).toBe('MCP: connecting...');
+  });
+
+  test('shows connected servers with tool counts', () => {
+    const status: McpStatusMap = new Map([
+      ['github', { status: 'connected', toolCount: 3 }],
+      ['context7', { status: 'connected', toolCount: 2 }],
+    ]);
+    expect(formatMcpStatus(status, false)).toBe('MCP: github(3) context7(2)');
+  });
+
+  test('shows error state as (err)', () => {
+    const status: McpStatusMap = new Map([
+      ['github', { status: 'error', toolCount: 0, error: 'Connection failed' }],
+    ]);
+    expect(formatMcpStatus(status, false)).toBe('MCP: github(err)');
+  });
+
+  test('shows connecting state as (...)', () => {
+    const status: McpStatusMap = new Map([
+      ['github', { status: 'connecting', toolCount: 0 }],
+    ]);
+    expect(formatMcpStatus(status, false)).toBe('MCP: github(...)');
+  });
+
+  test('shows disconnected state as (off)', () => {
+    const status: McpStatusMap = new Map([
+      ['github', { status: 'disconnected', toolCount: 0 }],
+    ]);
+    expect(formatMcpStatus(status, false)).toBe('MCP: github(off)');
+  });
+
+  test('shows mixed status correctly', () => {
+    const status: McpStatusMap = new Map([
+      ['github', { status: 'connected', toolCount: 3 }],
+      ['badserver', { status: 'error', toolCount: 0, error: 'timeout' }],
+      ['context7', { status: 'connected', toolCount: 2 }],
+    ]);
+    expect(formatMcpStatus(status, false)).toBe(
+      'MCP: github(3) badserver(err) context7(2)',
+    );
+  });
+});


### PR DESCRIPTION
## Issue #93: MCP TUI Integration

Implements all four sub-tasks from the MCP TUI Integration spec (Issue E).

### Changes

**E.1 Status Bar** — Shows MCP server status and tool counts in the status bar:
```
[BUILD] • llama3.2:latest • MCP: github(3) context7(2)
[BUILD] • llama3.2:latest • MCP: github(err) context7(2)
[BUILD] • llama3.2:latest • MCP: connecting...
```

**E.2 `/mcp` Slash Command** — Opens a modal showing:
- Server list with connection status
- Tool counts and tool names with descriptions
- Error messages for failed servers
- Last 5 stderr lines for debugging

**E.3 Tool Call Display** — MCP tool calls render as `server > tool` instead of the raw `mcp__server__tool` qualified name. MCP tools are expandable with Ctrl+E.

**E.4 Toast Notifications** — On startup, toasts fire for each server:
- `MCP: github connected (3 tools)`
- `MCP: badserver failed to connect`

### Architecture

- **`useMcp` hook** (`src/tui/hooks/use-mcp.ts`) — Creates McpManager, connects servers from config, exposes reactive signals for status/tools, registers MCP tools into the shared tools array, handles cleanup on unmount.
- **`mcp-display.ts`** (`src/tui/utils/`) — Pure utility functions extracted for testability: `parseMcpToolName`, `getToolDisplayName`, `formatMcpStatus`.
- **`McpStatusModal`** — Reuses the existing Modal component pattern.
- **mcpTools wired as signal accessor** to `useAgentSubmit` for reactive permissions and mode filtering.

### Review fixes applied
- mcpTools passed as signal accessor (not unwrapped value) for SolidJS reactivity
- onCleanup moved outside onMount for unconditional cleanup
- .catch() added to connectAll promise to handle initialization errors

### Tests
- 16 new unit tests for display utilities
- All 114 MCP tests pass, tsc clean

### Files changed (12)
- 4 new: `use-mcp.ts`, `mcp-status-modal.tsx`, `mcp-display.ts`, `test-mcp-tui.ts`
- 8 modified: `index.tsx`, `status-bar.tsx`, `input-box.tsx`, `tool-message.tsx`, `use-command-menu.ts`, `use-agent-submit.ts`, barrel exports

Closes #93