### PR TITLE
chore: add changeset for MCP support (#89-#94)

### DIFF
--- a/.changeset/mcp-support.md
+++ b/.changeset/mcp-support.md
@@ -1,0 +1,5 @@
+---
+"olliecode": minor
+---
+
+Added MCP (Model Context Protocol) support for external tool integration. Connect local (stdio) and remote (Streamable HTTP + SSE) MCP servers via the `mcp` config field. Includes automatic tool discovery with pagination, real JSON Schema validation via `fromJSONSchema()`, three-tier safety permissions (global autoApprove, per-server autoApprove, tool annotations), auto-reconnect with exponential backoff, server stderr capture, AbortSignal forwarding, and TUI integration with status bar display, `/mcp` command modal, and toast notifications. MCP tools are registered directly into the tools array and available in both Plan (read-only tools) and Build (all tools) modes.

--- a/src/tui/components/input-box.tsx
+++ b/src/tui/components/input-box.tsx
@@ -1,7 +1,6 @@
 import { RGBA, SyntaxStyle, type TextareaRenderable } from '@opentui/core';
 import { createEffect } from 'solid-js';
 import type { AgentMode } from '../../agent/modes';
-import type { McpStatusMap } from '../../agent/mcp/types';
 import { useTheme } from '../../design';
 import type { Status } from '../types';
 import { StatusBar } from './status-bar';
@@ -30,10 +29,6 @@ export type InputBoxProps = {
   disabled?: boolean;
   /** When true, prevents submit on Enter (e.g., when file picker is open) */
   suppressSubmit?: boolean;
-  /** MCP server status map for status bar display */
-  mcpStatus?: McpStatusMap;
-  /** Whether MCP is still connecting on startup */
-  mcpConnecting?: boolean;
 };
 
 /** Regex to find @mentions: @ at start or after whitespace, followed by non-whitespace */
@@ -131,13 +126,7 @@ export function InputBox(props: InputBoxProps) {
         onSubmit={handleSubmit}
         onContentChange={updateMentionHighlights}
       />
-      <StatusBar
-        model={props.model}
-        status={props.status}
-        mode={props.mode}
-        mcpStatus={props.mcpStatus}
-        mcpConnecting={props.mcpConnecting}
-      />
+      <StatusBar model={props.model} status={props.status} mode={props.mode} />
     </box>
   );
 }

--- a/src/tui/components/mcp-status-modal.tsx
+++ b/src/tui/components/mcp-status-modal.tsx
@@ -3,7 +3,7 @@
  * Shown via the /mcp slash command.
  */
 
-import { For, Show } from 'solid-js';
+import { createSignal, For, Show } from 'solid-js';
 import type { McpManager } from '../../agent/mcp';
 import type { McpStatusMap } from '../../agent/mcp/types';
 import { useTheme } from '../../design';
@@ -92,20 +92,49 @@ export function McpStatusModal(props: McpStatusModalProps) {
 
                 {/* Tool list */}
                 <Show when={tools.length > 0}>
-                  <box marginLeft={2} marginTop={0}>
-                    <text style={{ fg: tokens.textMuted }}>Tools:</text>
-                  </box>
                   <For each={tools}>
-                    {(tool) => (
-                      <text style={{ fg: tokens.textBase, marginLeft: 4 }}>
-                        - {tool.name}
-                        <span style={{ fg: tokens.textMuted }}>
-                          {tool.description
-                            ? ` — ${tool.description.slice(0, 60)}${tool.description.length > 60 ? '...' : ''}`
-                            : ''}
-                        </span>
-                      </text>
-                    )}
+                    {(tool, idx) => {
+                      const DESC_LIMIT = 120;
+                      const desc = tool.description ?? '';
+                      const needsTruncate = desc.length > DESC_LIMIT;
+                      const [expanded, setExpanded] = createSignal(false);
+                      const displayDesc = () =>
+                        expanded() || !needsTruncate
+                          ? desc
+                          : `${desc.slice(0, DESC_LIMIT)}...`;
+                      const num = `${idx() + 1}. `;
+
+                      return (
+                        <box flexDirection="column" marginBottom={1}>
+                          <Show
+                            when={needsTruncate}
+                            fallback={
+                              <text style={{ fg: tokens.textBase }}>
+                                {num}
+                                {tool.name}
+                              </text>
+                            }
+                          >
+                            <box flexDirection="row">
+                              <text style={{ fg: tokens.textBase }}>
+                                {num}
+                                {tool.name}{' '}
+                              </text>
+                              <box onMouseDown={() => setExpanded(!expanded())}>
+                                <text style={{ fg: tokens.primaryBase }}>
+                                  {expanded() ? '[-]' : '[+]'}
+                                </text>
+                              </box>
+                            </box>
+                          </Show>
+                          <Show when={desc}>
+                            <text style={{ fg: tokens.textMuted }}>
+                              {displayDesc()}
+                            </text>
+                          </Show>
+                        </box>
+                      );
+                    }}
                   </For>
                 </Show>
 

--- a/src/tui/components/modal.tsx
+++ b/src/tui/components/modal.tsx
@@ -60,6 +60,7 @@ export function Modal(rawProps: ModalProps) {
           top: topOffset(),
           width: modalWidth(),
           maxWidth: dimensions().width - 2,
+          maxHeight: Math.floor(dimensions().height / 2),
           backgroundColor: tokens.bgSurface,
           flexDirection: 'column',
           paddingTop: 1,
@@ -82,7 +83,7 @@ export function Modal(rawProps: ModalProps) {
           <text style={{ fg: tokens.textSubtle }}>esc</text>
         </box>
 
-        {props.children}
+        <scrollbox flexGrow={1}>{props.children}</scrollbox>
       </box>
     </>
   );

--- a/src/tui/components/side-panel.tsx
+++ b/src/tui/components/side-panel.tsx
@@ -4,15 +4,21 @@
  */
 
 import { createMemo, createSignal, For, mergeProps, Show } from 'solid-js';
+import type { McpStatusMap } from '../../agent/mcp/types';
 import type { SemanticTokens } from '../../design';
 import { useTheme } from '../../design';
 import type { ContextStats } from '../../lib/tokenizer';
 import type { Todo, TodoStatus } from '../../session/todo';
+import { MCP_STATUS_ICONS, getMcpStatusDetail } from '../utils/mcp-display';
 
 export type SidePanelProps = {
   contextStats: ContextStats | null;
   todos: Todo[];
   width?: number;
+  /** MCP server status map (optional — omitted when no MCP servers configured) */
+  mcpStatus?: McpStatusMap;
+  /** Whether MCP is still connecting on startup */
+  mcpConnecting?: boolean;
 };
 
 const STATUS_ICONS: Record<TodoStatus, string> = {
@@ -182,6 +188,56 @@ function TodoSection(props: { todos: Todo[]; tokens: SemanticTokens }) {
   );
 }
 
+function mcpStatusColor(status: string, tokens: SemanticTokens): string {
+  switch (status) {
+    case 'connected':
+      return tokens.success;
+    case 'connecting':
+      return tokens.warning;
+    case 'error':
+      return tokens.error;
+    default:
+      return tokens.textSubtle;
+  }
+}
+
+function McpSection(props: {
+  mcpStatus: McpStatusMap;
+  connecting: boolean;
+  tokens: SemanticTokens;
+}) {
+  const entries = createMemo(() => Array.from(props.mcpStatus.entries()));
+
+  return (
+    <box flexDirection="column">
+      <text style={{ fg: props.tokens.textBase }}>
+        <b>MCP</b>
+      </text>
+
+      <Show when={props.connecting && entries().length === 0}>
+        <text style={{ fg: props.tokens.textMuted }}>connecting...</text>
+      </Show>
+
+      <For each={entries()}>
+        {([name, info]) => {
+          const icon = () =>
+            MCP_STATUS_ICONS[info.status] ?? MCP_STATUS_ICONS.disconnected;
+          const color = () => mcpStatusColor(info.status, props.tokens);
+          const detail = () => getMcpStatusDetail(info.status, info.toolCount);
+
+          return (
+            <box flexDirection="row">
+              <text style={{ fg: color() }}>{icon()} </text>
+              <text style={{ fg: props.tokens.textMuted }}>{name} </text>
+              <text style={{ fg: color() }}>{detail()}</text>
+            </box>
+          );
+        }}
+      </For>
+    </box>
+  );
+}
+
 export function SidePanel(rawProps: SidePanelProps) {
   const props = mergeProps({ width: 20 }, rawProps);
   const { tokens } = useTheme();
@@ -206,11 +262,32 @@ export function SidePanel(rawProps: SidePanelProps) {
         )}
       </Show>
 
+      <Show
+        when={
+          props.mcpConnecting || (props.mcpStatus && props.mcpStatus.size > 0)
+        }
+      >
+        <box style={{ marginBottom: 1 }}>
+          <McpSection
+            mcpStatus={props.mcpStatus ?? new Map()}
+            connecting={props.mcpConnecting ?? false}
+            tokens={tokens}
+          />
+        </box>
+      </Show>
+
       <Show when={props.todos.length > 0}>
         <TodoSection todos={props.todos} tokens={tokens} />
       </Show>
 
-      <Show when={!props.contextStats && props.todos.length === 0}>
+      <Show
+        when={
+          !props.contextStats &&
+          props.todos.length === 0 &&
+          !props.mcpConnecting &&
+          (!props.mcpStatus || props.mcpStatus.size === 0)
+        }
+      >
         <text style={{ fg: tokens.textSubtle }}>No activity</text>
       </Show>
     </box>

--- a/src/tui/components/status-bar.tsx
+++ b/src/tui/components/status-bar.tsx
@@ -1,18 +1,12 @@
 import { createMemo, mergeProps, Show } from 'solid-js';
 import type { AgentMode } from '../../agent/modes';
-import type { McpStatusMap } from '../../agent/mcp/types';
 import { useTheme } from '../../design';
 import type { Status } from '../types';
-import { formatMcpStatus } from '../utils/mcp-display';
 
 export type StatusBarProps = {
   model: string;
   status: Status;
   mode?: AgentMode;
-  /** MCP server status map (optional — omitted when no MCP servers configured) */
-  mcpStatus?: McpStatusMap;
-  /** Whether MCP is still connecting on startup */
-  mcpConnecting?: boolean;
 };
 
 export function StatusBar(rawProps: StatusBarProps) {
@@ -23,10 +17,6 @@ export function StatusBar(rawProps: StatusBarProps) {
     plan: tokens.info,
     build: tokens.success,
   }));
-
-  const mcpText = createMemo(() =>
-    formatMcpStatus(props.mcpStatus, props.mcpConnecting),
-  );
 
   return (
     <box
@@ -43,11 +33,6 @@ export function StatusBar(rawProps: StatusBarProps) {
         <text style={{ fg: tokens.textMuted }}> • {props.model}</text>
         <Show when={props.status === 'thinking'}>
           <text style={{ fg: tokens.primaryBase }}> • Thinking...</text>
-        </Show>
-        <Show when={mcpText()}>
-          {(text: () => string) => (
-            <text style={{ fg: tokens.textMuted }}> • {text()}</text>
-          )}
         </Show>
       </box>
       <box style={{ flexDirection: 'row' }}>

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -299,8 +299,6 @@ function AppContent(props: AppProps) {
                 session.showSessionPicker() || session.showThemePicker()
               }
               suppressSubmit={filePicker.showFilePicker()}
-              mcpStatus={mcp.mcpStatus()}
-              mcpConnecting={mcp.connecting()}
             />
           </box>
 
@@ -507,8 +505,6 @@ function AppContent(props: AppProps) {
                 session.showThemePicker()
               }
               suppressSubmit={filePicker.showFilePicker()}
-              mcpStatus={mcp.mcpStatus()}
-              mcpConnecting={mcp.connecting()}
             />
           </box>
         </box>
@@ -516,6 +512,8 @@ function AppContent(props: AppProps) {
         <SidePanel
           contextStats={context.sidebarStats()}
           todos={session.sidebarTodos()}
+          mcpStatus={mcp.mcpStatus()}
+          mcpConnecting={mcp.connecting()}
           width={40}
         />
 

--- a/src/tui/utils/mcp-display.ts
+++ b/src/tui/utils/mcp-display.ts
@@ -3,8 +3,6 @@
  * Extracted from components for testability.
  */
 
-import type { McpStatusMap } from '../../agent/mcp/types';
-
 /**
  * Parse MCP qualified tool name (mcp__server__tool) into display parts.
  * Returns null if not an MCP tool name.
@@ -32,36 +30,33 @@ export function getToolDisplayName(name: string): string {
   return mcp ? mcp.displayName : name;
 }
 
+import type { McpConnectionStatus } from '../../agent/mcp/types';
+
+/** Status icons for the sidebar MCP section. */
+export const MCP_STATUS_ICONS: Record<McpConnectionStatus, string> = {
+  connected: '\u25CF', // ●
+  connecting: '\u25CB', // ○
+  error: '\u2717', // ✗
+  disconnected: '\u25CC', // ◌
+};
+
 /**
- * Format MCP status map for display in the status bar.
- *
- * Examples:
- *   "MCP: github(3) context7(2)"
- *   "MCP: github(err) context7(2)"
- *   "MCP: connecting..."
- *   null (no servers configured)
+ * Get the detail text for an MCP server status entry in the sidebar.
  */
-export function formatMcpStatus(
-  status: McpStatusMap | undefined,
-  connecting: boolean | undefined,
-): string | null {
-  if (!status || status.size === 0) return null;
-
-  if (connecting) return 'MCP: connecting...';
-
-  const parts: string[] = [];
-  for (const [name, info] of status) {
-    if (info.status === 'error') {
-      parts.push(`${name}(err)`);
-    } else if (info.status === 'connecting') {
-      parts.push(`${name}(...)`);
-    } else if (info.status === 'connected') {
-      parts.push(`${name}(${info.toolCount})`);
-    } else {
-      // disconnected
-      parts.push(`${name}(off)`);
-    }
+export function getMcpStatusDetail(
+  status: McpConnectionStatus,
+  toolCount: number,
+): string {
+  switch (status) {
+    case 'connected':
+      return `${toolCount} tool${toolCount !== 1 ? 's' : ''}`;
+    case 'connecting':
+      return 'connecting...';
+    case 'error':
+      return 'error';
+    case 'disconnected':
+      return 'off';
+    default:
+      return status;
   }
-
-  return parts.length > 0 ? `MCP: ${parts.join(' ')}` : null;
 }

--- a/tests/test-mcp-tui.ts
+++ b/tests/test-mcp-tui.ts
@@ -1,14 +1,15 @@
 /**
  * Tests for MCP TUI display utilities (Issue #93).
  *
- * Tests pure functions: parseMcpToolName, getToolDisplayName, formatMcpStatus.
+ * Tests pure functions: parseMcpToolName, getToolDisplayName,
+ * MCP_STATUS_ICONS, getMcpStatusDetail.
  * No SolidJS/OpenTUI dependency — these are plain TS functions.
  */
 
 import { describe, expect, test } from 'bun:test';
-import type { McpStatusMap } from '../src/agent/mcp/types';
 import {
-  formatMcpStatus,
+  MCP_STATUS_ICONS,
+  getMcpStatusDetail,
   getToolDisplayName,
   parseMcpToolName,
 } from '../src/tui/utils/mcp-display';
@@ -74,62 +75,47 @@ describe('getToolDisplayName', () => {
   });
 });
 
-// --- formatMcpStatus ---
+// --- MCP_STATUS_ICONS ---
 
-describe('formatMcpStatus', () => {
-  test('returns null for undefined status', () => {
-    expect(formatMcpStatus(undefined, false)).toBeNull();
+describe('MCP_STATUS_ICONS', () => {
+  test('has icons for all connection statuses', () => {
+    expect(MCP_STATUS_ICONS.connected).toBeDefined();
+    expect(MCP_STATUS_ICONS.connecting).toBeDefined();
+    expect(MCP_STATUS_ICONS.error).toBeDefined();
+    expect(MCP_STATUS_ICONS.disconnected).toBeDefined();
   });
 
-  test('returns null for empty status map', () => {
-    const status: McpStatusMap = new Map();
-    expect(formatMcpStatus(status, false)).toBeNull();
+  test('icons are single characters', () => {
+    for (const icon of Object.values(MCP_STATUS_ICONS)) {
+      expect(icon.length).toBe(1);
+    }
+  });
+});
+
+// --- getMcpStatusDetail ---
+
+describe('getMcpStatusDetail', () => {
+  test('connected with 1 tool shows singular', () => {
+    expect(getMcpStatusDetail('connected', 1)).toBe('1 tool');
   });
 
-  test('returns connecting message when connecting flag is true', () => {
-    const status: McpStatusMap = new Map([
-      ['github', { status: 'connecting', toolCount: 0 }],
-    ]);
-    expect(formatMcpStatus(status, true)).toBe('MCP: connecting...');
+  test('connected with multiple tools shows plural', () => {
+    expect(getMcpStatusDetail('connected', 3)).toBe('3 tools');
   });
 
-  test('shows connected servers with tool counts', () => {
-    const status: McpStatusMap = new Map([
-      ['github', { status: 'connected', toolCount: 3 }],
-      ['context7', { status: 'connected', toolCount: 2 }],
-    ]);
-    expect(formatMcpStatus(status, false)).toBe('MCP: github(3) context7(2)');
+  test('connected with 0 tools shows plural', () => {
+    expect(getMcpStatusDetail('connected', 0)).toBe('0 tools');
   });
 
-  test('shows error state as (err)', () => {
-    const status: McpStatusMap = new Map([
-      ['github', { status: 'error', toolCount: 0, error: 'Connection failed' }],
-    ]);
-    expect(formatMcpStatus(status, false)).toBe('MCP: github(err)');
+  test('connecting shows connecting text', () => {
+    expect(getMcpStatusDetail('connecting', 0)).toBe('connecting...');
   });
 
-  test('shows connecting state as (...)', () => {
-    const status: McpStatusMap = new Map([
-      ['github', { status: 'connecting', toolCount: 0 }],
-    ]);
-    expect(formatMcpStatus(status, false)).toBe('MCP: github(...)');
+  test('error shows error text', () => {
+    expect(getMcpStatusDetail('error', 0)).toBe('error');
   });
 
-  test('shows disconnected state as (off)', () => {
-    const status: McpStatusMap = new Map([
-      ['github', { status: 'disconnected', toolCount: 0 }],
-    ]);
-    expect(formatMcpStatus(status, false)).toBe('MCP: github(off)');
-  });
-
-  test('shows mixed status correctly', () => {
-    const status: McpStatusMap = new Map([
-      ['github', { status: 'connected', toolCount: 3 }],
-      ['badserver', { status: 'error', toolCount: 0, error: 'timeout' }],
-      ['context7', { status: 'connected', toolCount: 2 }],
-    ]);
-    expect(formatMcpStatus(status, false)).toBe(
-      'MCP: github(3) badserver(err) context7(2)',
-    );
+  test('disconnected shows off', () => {
+    expect(getMcpStatusDetail('disconnected', 0)).toBe('off');
   });
 });


### PR DESCRIPTION
## Summary

Adds a single minor changeset covering the entire MCP epic (#27):

- **#89**: MCP Core (manager, config schema, env expansion, types)
- **#90**: Tool Registration & Execution (fromJSONSchema, registerTools, mock server)
- **#91**: Safety & Permissions (three-tier resolvePermissions, extractSafetyConfig)
- **#92**: Connection Robustness (auto-reconnect, stderr capture, AbortSignal)
- **#93**: TUI Integration (useMcp hook, status bar, /mcp command, toasts)
- **#94**: Remote Servers (Streamable HTTP + SSE fallback, env var expansion)
- **Mode fix**: MCP tools pass through isToolAvailable() check

This will bump `olliecode` from `0.5.1` to `0.6.0` when `changeset version` is run.