### PR TITLE
feat(agent): Story 2 — Agent Schema + Loader

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "commander": "^14.0.3",
         "diff": "^8.0.3",
         "fuse.js": "^7.1.0",
+        "gray-matter": "^4.0.3",
         "jsonc-parser": "^3.3.1",
         "ollama": "^0.6.3",
         "solid-js": "1.9.9",
@@ -1255,6 +1256,8 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
+    "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
+
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -1378,6 +1381,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
 
     "gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
 
@@ -1555,7 +1560,7 @@
 
     "keyv-file": ["keyv-file@5.3.3", "", { "dependencies": { "@keyv/serialize": "^1.1.1", "tslib": "^1.14.1" } }, "sha512-uCFUhiVYf+BcA6DP4smhnRLOR4yzUUA15yJSk4/rP5oAPnF3MpfajejwvSV8l+okm+EGiW4IHP3gn+xahpvZcQ=="],
 
-    "kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
+    "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
     "kuler": ["kuler@2.0.0", "", {}, "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="],
 
@@ -1975,6 +1980,8 @@
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
+    "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
+
     "secure-compare": ["secure-compare@3.0.1", "", {}, "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw=="],
 
     "seedrandom": ["seedrandom@3.0.5", "", {}, "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="],
@@ -2080,6 +2087,8 @@
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
+
+    "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
@@ -2409,6 +2418,8 @@
 
     "cli-truncate/string-width": ["string-width@8.1.1", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw=="],
 
+    "clone-deep/kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
+
     "color/color-convert": ["color-convert@3.1.3", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="],
 
     "color-string/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
@@ -2445,6 +2456,8 @@
 
     "global-agent/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "gray-matter/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+
     "http-proxy/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "http-server/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -2474,6 +2487,8 @@
     "macos-version/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "matcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "merge-deep/kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
 
     "mixin-object/for-in": ["for-in@0.1.8", "", {}, "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g=="],
 
@@ -2640,6 +2655,8 @@
     "engine.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "http-server/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "commander": "^14.0.3",
     "diff": "^8.0.3",
     "fuse.js": "^7.1.0",
+    "gray-matter": "^4.0.3",
     "jsonc-parser": "^3.3.1",
     "ollama": "^0.6.3",
     "solid-js": "1.9.9",

--- a/src/agent/agents/loader.ts
+++ b/src/agent/agents/loader.ts
@@ -1,0 +1,215 @@
+/**
+ * Agent file discovery and parsing.
+ *
+ * Discovers agent markdown files from global (~/.config/ollie/agents/) and
+ * project (.ollie/agents/) directories, parses YAML frontmatter + markdown body,
+ * validates against AgentInfoSchema, and returns resolved agent definitions.
+ */
+
+import { Glob } from 'bun';
+import matter from 'gray-matter';
+import path from 'node:path';
+
+import { AgentInfoSchema } from './schema';
+import type { AgentSource, ResolvedAgent } from './schema';
+
+/** Result of loading agents from a single scope. */
+export type LoadResult = {
+  agents: ResolvedAgent[];
+  warnings: LoadWarning[];
+};
+
+export type LoadWarning = {
+  path: string;
+  message: string;
+};
+
+/**
+ * Parse a single markdown agent file into a ResolvedAgent.
+ *
+ * @param filePath - Absolute path to the .md file
+ * @param source - Where this file was found (global/project)
+ * @returns The parsed agent, or a warning if parsing/validation failed
+ */
+export function parseAgentFile(
+  filePath: string,
+  source: AgentSource,
+): ResolvedAgent | LoadWarning {
+  let content: string;
+  try {
+    content = require('fs').readFileSync(filePath, 'utf-8');
+  } catch {
+    return { path: filePath, message: 'Could not read file' };
+  }
+
+  return parseAgentMarkdown(content, filePath, source);
+}
+
+/**
+ * Parse markdown content (with frontmatter) into a ResolvedAgent.
+ * Exported for testing without filesystem access.
+ */
+export function parseAgentMarkdown(
+  content: string,
+  filePath: string,
+  source: AgentSource,
+): ResolvedAgent | LoadWarning {
+  let parsed: matter.GrayMatterFile<string>;
+  try {
+    parsed = matter(content);
+  } catch {
+    return { path: filePath, message: 'Invalid YAML frontmatter' };
+  }
+
+  const result = AgentInfoSchema.safeParse(parsed.data);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `${i.path.join('.')}: ${i.message}`)
+      .join('; ');
+    return { path: filePath, message: `Schema validation failed: ${issues}` };
+  }
+
+  const info = result.data;
+
+  // Name: frontmatter `name` field, or filename without extension as fallback
+  const name = info.name ?? path.basename(filePath, '.md');
+
+  return {
+    ...info,
+    name,
+    systemPrompt: parsed.content.trim(),
+    source,
+  };
+}
+
+/**
+ * Discover and load all agent markdown files from a directory (recursive).
+ *
+ * @param dir - Directory to scan for `**\/*.md` files
+ * @param sourceType - "global" or "project"
+ * @returns Loaded agents and any warnings
+ */
+export async function loadAgentsFromDirectory(
+  dir: string,
+  sourceType: 'global' | 'project',
+): Promise<LoadResult> {
+  const agents: ResolvedAgent[] = [];
+  const warnings: LoadWarning[] = [];
+
+  // Check if directory exists
+  const fs = await import('node:fs/promises');
+  try {
+    await fs.access(dir);
+  } catch {
+    // Directory doesn't exist — not an error, just no agents from this scope
+    return { agents, warnings };
+  }
+
+  const glob = new Glob('**/*.md');
+  const entries: string[] = [];
+
+  for await (const entry of glob.scan({ cwd: dir, absolute: false })) {
+    entries.push(entry);
+  }
+
+  // Sort for deterministic order
+  entries.sort();
+
+  for (const entry of entries) {
+    const filePath = path.join(dir, entry);
+    const source: AgentSource = { type: sourceType, path: filePath };
+    const result = parseAgentFile(filePath, source);
+
+    if ('message' in result) {
+      warnings.push(result);
+    } else {
+      agents.push(result);
+    }
+  }
+
+  // Check for duplicate names within this scope
+  const seen = new Map<string, string>();
+  const deduped: ResolvedAgent[] = [];
+
+  for (const agent of agents) {
+    const existing = seen.get(agent.name);
+    if (existing) {
+      const sourcePath =
+        agent.source.type === 'global' || agent.source.type === 'project'
+          ? agent.source.path
+          : 'unknown';
+      warnings.push({
+        path: sourcePath,
+        message: `Duplicate agent name "${agent.name}" (already defined in ${existing})`,
+      });
+    } else {
+      const sourcePath =
+        agent.source.type === 'global' || agent.source.type === 'project'
+          ? agent.source.path
+          : 'unknown';
+      seen.set(agent.name, sourcePath);
+      deduped.push(agent);
+    }
+  }
+
+  return { agents: deduped, warnings };
+}
+
+/**
+ * Load agents from both global and project scopes, applying precedence rules.
+ *
+ * Precedence: project overrides global for the same agent name.
+ * `disabled: true` in project scope suppresses a global agent.
+ *
+ * @param globalDir - Global agents directory (~/.config/ollie/agents/)
+ * @param projectDir - Project agents directory (.ollie/agents/)
+ * @returns Merged agents and all warnings
+ */
+export async function loadAllAgents(
+  globalDir: string,
+  projectDir: string,
+): Promise<LoadResult> {
+  const [globalResult, projectResult] = await Promise.all([
+    loadAgentsFromDirectory(globalDir, 'global'),
+    loadAgentsFromDirectory(projectDir, 'project'),
+  ]);
+
+  const warnings = [...globalResult.warnings, ...projectResult.warnings];
+
+  // Build map: start with global, then project overrides
+  const agentMap = new Map<string, ResolvedAgent>();
+
+  for (const agent of globalResult.agents) {
+    agentMap.set(agent.name, agent);
+  }
+
+  for (const agent of projectResult.agents) {
+    agentMap.set(agent.name, agent);
+  }
+
+  // Filter out disabled agents
+  const agents: ResolvedAgent[] = [];
+  for (const agent of agentMap.values()) {
+    if (agent.disabled) {
+      // Not a warning — intentional suppression
+      continue;
+    }
+    agents.push(agent);
+  }
+
+  return { agents, warnings };
+}
+
+/**
+ * Default directory paths for agent discovery.
+ */
+export function getDefaultAgentDirs(projectRoot: string): {
+  globalDir: string;
+  projectDir: string;
+} {
+  const home = process.env['HOME'] ?? process.env['USERPROFILE'] ?? '~';
+  return {
+    globalDir: path.join(home, '.config', 'ollie', 'agents'),
+    projectDir: path.join(projectRoot, '.ollie', 'agents'),
+  };
+}

--- a/src/agent/agents/schema.ts
+++ b/src/agent/agents/schema.ts
@@ -1,0 +1,90 @@
+/**
+ * Agent definition schema using Zod.
+ *
+ * Defines the shape of agent configurations as found in:
+ * - Markdown frontmatter (`.ollie/agents/*.md`, `~/.config/ollie/agents/*.md`)
+ * - JSON config (`ollie.json` → `agents` field)
+ */
+
+import { z } from 'zod';
+
+import type { PermissionConfig } from '../permission/types';
+
+// === Permission schema (matches PermissionConfig type) ===
+
+const PermissionActionSchema = z.enum(['allow', 'ask', 'deny']);
+
+const PermissionRuleSchema = z.union([
+  PermissionActionSchema,
+  z.record(z.string(), PermissionActionSchema),
+]);
+
+export const PermissionConfigSchema: z.ZodType<PermissionConfig> = z.record(
+  z.string(),
+  PermissionRuleSchema,
+);
+
+// === Max iterations ===
+
+const MaxIterationsPresetSchema = z.enum(['quick', 'medium', 'thorough']);
+
+export const ITERATION_PRESETS = {
+  quick: 8,
+  medium: 15,
+  thorough: 25,
+} as const;
+
+const MaxIterationsSchema = z.union([
+  z.number().int().positive(),
+  MaxIterationsPresetSchema,
+]);
+
+// === Agent mode ===
+
+export const AgentModeSchema = z.enum(['primary', 'subagent', 'all']);
+
+// === Agent definition schema ===
+
+const AgentInfoObjectSchema = z.object({
+  /** Agent name. Required in JSON config; optional in markdown (filename fallback). */
+  name: z.string().optional(),
+  /** Description shown in task tool dynamic listing. Required. */
+  description: z.string(),
+  /** Whether this agent can be used as primary, subagent, or both. */
+  mode: AgentModeSchema.default('subagent'),
+  /** Ollama model override. */
+  model: z.string().optional(),
+  /** Temperature override. */
+  temperature: z.number().min(0).max(2).optional(),
+  /** Iteration budget — number or named preset. */
+  maxIterations: MaxIterationsSchema.optional(),
+  /** Permission ruleset controlling tool access. */
+  permission: PermissionConfigSchema.optional(),
+  /** If true, this agent is suppressed (project can disable a global agent). */
+  disabled: z.boolean().default(false),
+});
+
+export const AgentInfoSchema = AgentInfoObjectSchema;
+
+/** Agent definition as parsed from config (all defaults applied). */
+export type AgentInfo = z.output<typeof AgentInfoSchema>;
+
+/** Agent definition as written in config files (optional fields). */
+export type AgentInfoInput = z.input<typeof AgentInfoSchema>;
+
+// === Resolved agent (fully loaded with source metadata) ===
+
+export type ResolvedAgent = AgentInfo & {
+  /** Canonical agent name (from frontmatter `name` field or filename fallback). */
+  name: string;
+  /** System prompt (markdown body for file-based agents, empty for JSON-only). */
+  systemPrompt: string;
+  /** Where this agent was loaded from. */
+  source: AgentSource;
+};
+
+export type AgentSource =
+  | { type: 'builtin' }
+  | { type: 'global'; path: string }
+  | { type: 'project'; path: string }
+  | { type: 'config' };

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -9,6 +9,8 @@
 
 import { z } from 'zod';
 
+import { AgentInfoSchema } from '../agent/agents/schema';
+
 // === Shared enums ===
 
 export const AutonomyLevelSchema = z.enum([
@@ -272,6 +274,10 @@ export const ConfigSchema = z.object({
   tui: TuiSchema,
 
   mcp: z.record(McpServerNameSchema, McpServerConfigSchema).default({}),
+
+  agents: z
+    .record(z.string(), AgentInfoSchema.extend({ name: z.string() }))
+    .default({}),
 
   instructions: z.array(z.string()).default([]),
 

--- a/tests/test-agent-loader.ts
+++ b/tests/test-agent-loader.ts
@@ -1,0 +1,568 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  loadAgentsFromDirectory,
+  loadAllAgents,
+  parseAgentMarkdown,
+} from '../src/agent/agents/loader';
+import type { AgentSource, ResolvedAgent } from '../src/agent/agents/schema';
+import type { LoadWarning } from '../src/agent/agents/loader';
+
+// Helper to check if result is a warning
+function isWarning(result: ResolvedAgent | LoadWarning): result is LoadWarning {
+  return 'message' in result;
+}
+
+const TEST_DIR = path.join(import.meta.dir, '.test-agents');
+const GLOBAL_DIR = path.join(TEST_DIR, 'global');
+const PROJECT_DIR = path.join(TEST_DIR, 'project');
+
+const projectSource: AgentSource = { type: 'project', path: 'test.md' };
+
+// ─── parseAgentMarkdown (unit tests — no filesystem) ─────────────────
+
+describe('parseAgentMarkdown', () => {
+  it('parses valid markdown with frontmatter', () => {
+    const content = `---
+description: Reviews code for quality
+mode: subagent
+---
+
+You are a code reviewer. Analyze code quality.`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/reviewer.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(false);
+    if (isWarning(result)) return;
+
+    expect(result.name).toBe('reviewer');
+    expect(result.description).toBe('Reviews code for quality');
+    expect(result.mode).toBe('subagent');
+    expect(result.systemPrompt).toBe(
+      'You are a code reviewer. Analyze code quality.',
+    );
+  });
+
+  it('uses frontmatter name over filename', () => {
+    const content = `---
+name: my-reviewer
+description: Custom reviewer
+---
+
+Review things.`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/reviewer.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(false);
+    if (isWarning(result)) return;
+
+    expect(result.name).toBe('my-reviewer');
+  });
+
+  it('falls back to filename without extension when name is absent', () => {
+    const content = `---
+description: A helper agent
+---
+
+Help with stuff.`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/path/to/helper-agent.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(false);
+    if (isWarning(result)) return;
+
+    expect(result.name).toBe('helper-agent');
+  });
+
+  it('defaults mode to subagent when omitted', () => {
+    const content = `---
+description: Some agent
+---
+
+Do things.`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/test.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(false);
+    if (isWarning(result)) return;
+
+    expect(result.mode).toBe('subagent');
+  });
+
+  it('defaults disabled to false when omitted', () => {
+    const content = `---
+description: Some agent
+---
+
+Do things.`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/test.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(false);
+    if (isWarning(result)) return;
+
+    expect(result.disabled).toBe(false);
+  });
+
+  it('parses permission config', () => {
+    const content = `---
+description: Restricted agent
+permission:
+  "*": deny
+  read: allow
+  bash:
+    "*": deny
+    "git diff*": allow
+---
+
+Do restricted things.`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/restricted.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(false);
+    if (isWarning(result)) return;
+
+    expect(result.permission).toEqual({
+      '*': 'deny',
+      read: 'allow',
+      bash: { '*': 'deny', 'git diff*': 'allow' },
+    });
+  });
+
+  it('parses optional fields (model, temperature, maxIterations)', () => {
+    const content = `---
+description: Custom model agent
+model: llama3.1:70b
+temperature: 0.8
+maxIterations: 30
+---
+
+Use a custom model.`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/custom.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(false);
+    if (isWarning(result)) return;
+
+    expect(result.model).toBe('llama3.1:70b');
+    expect(result.temperature).toBe(0.8);
+    expect(result.maxIterations).toBe(30);
+  });
+
+  it('parses maxIterations as preset string', () => {
+    const content = `---
+description: Quick agent
+maxIterations: quick
+---
+
+Be quick.`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/quick.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(false);
+    if (isWarning(result)) return;
+
+    expect(result.maxIterations).toBe('quick');
+  });
+
+  it('returns warning for missing required description', () => {
+    const content = `---
+mode: subagent
+---
+
+No description here.`;
+
+    const result = parseAgentMarkdown(content, '/agents/bad.md', projectSource);
+    expect(isWarning(result)).toBe(true);
+    if (!isWarning(result)) return;
+
+    expect(result.message).toContain('Schema validation failed');
+    expect(result.message).toContain('description');
+  });
+
+  it('returns warning for invalid YAML frontmatter', () => {
+    const content = `---
+: this is invalid yaml [
+  not valid
+---
+
+Body text.`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/invalid.md',
+      projectSource,
+    );
+    // gray-matter may or may not throw on this — but schema validation should catch it
+    // if gray-matter parses it as weird data
+    expect(isWarning(result)).toBe(true);
+  });
+
+  it('returns warning for invalid permission action', () => {
+    const content = `---
+description: Bad perms
+permission:
+  "*": nope
+---
+
+Bad.`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/badperms.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(true);
+    if (!isWarning(result)) return;
+
+    expect(result.message).toContain('Schema validation failed');
+  });
+
+  it('returns warning for invalid mode value', () => {
+    const content = `---
+description: Bad mode
+mode: invalid
+---
+
+Bad.`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/badmode.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(true);
+    if (!isWarning(result)) return;
+
+    expect(result.message).toContain('Schema validation failed');
+  });
+
+  it('trims whitespace from system prompt body', () => {
+    const content = `---
+description: Trimmed
+---
+
+  
+  Content with leading/trailing whitespace.
+  
+`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/trim.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(false);
+    if (isWarning(result)) return;
+
+    expect(result.systemPrompt).toBe(
+      'Content with leading/trailing whitespace.',
+    );
+  });
+
+  it('handles empty body', () => {
+    const content = `---
+description: No body
+---`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/nobody.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(false);
+    if (isWarning(result)) return;
+
+    expect(result.systemPrompt).toBe('');
+  });
+
+  it('preserves source metadata', () => {
+    const content = `---
+description: Source test
+---
+
+Body.`;
+
+    const source: AgentSource = {
+      type: 'global',
+      path: '/home/.config/ollie/agents/test.md',
+    };
+    const result = parseAgentMarkdown(
+      content,
+      '/home/.config/ollie/agents/test.md',
+      source,
+    );
+    expect(isWarning(result)).toBe(false);
+    if (isWarning(result)) return;
+
+    expect(result.source).toEqual(source);
+  });
+});
+
+// ─── loadAgentsFromDirectory (filesystem tests) ─────────────────────��
+
+describe('loadAgentsFromDirectory', () => {
+  beforeAll(() => {
+    // Create test directory structure
+    fs.mkdirSync(path.join(PROJECT_DIR, 'nested'), { recursive: true });
+
+    // Valid agent
+    fs.writeFileSync(
+      path.join(PROJECT_DIR, 'reviewer.md'),
+      `---
+description: Code reviewer
+mode: subagent
+---
+
+Review code.`,
+    );
+
+    // Valid nested agent
+    fs.writeFileSync(
+      path.join(PROJECT_DIR, 'nested', 'explorer.md'),
+      `---
+description: Codebase explorer
+---
+
+Explore the codebase.`,
+    );
+
+    // Invalid agent (missing description)
+    fs.writeFileSync(
+      path.join(PROJECT_DIR, 'invalid.md'),
+      `---
+mode: subagent
+---
+
+No description.`,
+    );
+
+    // Disabled agent
+    fs.writeFileSync(
+      path.join(PROJECT_DIR, 'disabled-agent.md'),
+      `---
+description: Disabled agent
+disabled: true
+---
+
+I am disabled.`,
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('discovers agents recursively', async () => {
+    const result = await loadAgentsFromDirectory(PROJECT_DIR, 'project');
+    const names = result.agents.map((a) => a.name);
+    expect(names).toContain('reviewer');
+    expect(names).toContain('explorer');
+  });
+
+  it('reports warnings for invalid files', async () => {
+    const result = await loadAgentsFromDirectory(PROJECT_DIR, 'project');
+    expect(result.warnings.length).toBeGreaterThan(0);
+    const invalidWarning = result.warnings.find((w) =>
+      w.path.includes('invalid.md'),
+    );
+    expect(invalidWarning).toBeDefined();
+  });
+
+  it('returns empty result for nonexistent directory', async () => {
+    const result = await loadAgentsFromDirectory('/nonexistent/path', 'global');
+    expect(result.agents).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('detects duplicate names within scope', async () => {
+    // Create a second file that resolves to the same name
+    const dupeDir = path.join(TEST_DIR, 'dupes');
+    fs.mkdirSync(dupeDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(dupeDir, 'agent-a.md'),
+      `---
+name: same-name
+description: First agent
+---
+
+First.`,
+    );
+
+    fs.writeFileSync(
+      path.join(dupeDir, 'agent-b.md'),
+      `---
+name: same-name
+description: Second agent
+---
+
+Second.`,
+    );
+
+    const result = await loadAgentsFromDirectory(dupeDir, 'project');
+    // One agent loaded, one duplicate warning
+    const sameNameAgents = result.agents.filter((a) => a.name === 'same-name');
+    expect(sameNameAgents).toHaveLength(1);
+    const dupeWarning = result.warnings.find((w) =>
+      w.message.includes('Duplicate agent name'),
+    );
+    expect(dupeWarning).toBeDefined();
+
+    fs.rmSync(dupeDir, { recursive: true, force: true });
+  });
+
+  it('includes disabled agents in the raw result (filtering is in loadAllAgents)', async () => {
+    const result = await loadAgentsFromDirectory(PROJECT_DIR, 'project');
+    const disabledAgent = result.agents.find(
+      (a) => a.name === 'disabled-agent',
+    );
+    expect(disabledAgent).toBeDefined();
+    expect(disabledAgent?.disabled).toBe(true);
+  });
+});
+
+// ─── loadAllAgents (merge + precedence) ──────────────────────────────
+
+describe('loadAllAgents', () => {
+  const globalMergeDir = path.join(TEST_DIR, 'merge-global');
+  const projectMergeDir = path.join(TEST_DIR, 'merge-project');
+
+  beforeAll(() => {
+    fs.mkdirSync(globalMergeDir, { recursive: true });
+    fs.mkdirSync(projectMergeDir, { recursive: true });
+
+    // Global agent
+    fs.writeFileSync(
+      path.join(globalMergeDir, 'shared.md'),
+      `---
+description: Global version
+---
+
+I am global.`,
+    );
+
+    // Global-only agent
+    fs.writeFileSync(
+      path.join(globalMergeDir, 'global-only.md'),
+      `---
+description: Only in global
+---
+
+Global only.`,
+    );
+
+    // Project override of "shared"
+    fs.writeFileSync(
+      path.join(projectMergeDir, 'shared.md'),
+      `---
+description: Project version
+---
+
+I am project.`,
+    );
+
+    // Project-only agent
+    fs.writeFileSync(
+      path.join(projectMergeDir, 'project-only.md'),
+      `---
+description: Only in project
+---
+
+Project only.`,
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(path.join(TEST_DIR, 'merge-global'), {
+      recursive: true,
+      force: true,
+    });
+    fs.rmSync(path.join(TEST_DIR, 'merge-project'), {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it('project overrides global for same agent name', async () => {
+    const result = await loadAllAgents(globalMergeDir, projectMergeDir);
+    const shared = result.agents.find((a) => a.name === 'shared');
+    expect(shared).toBeDefined();
+    expect(shared?.description).toBe('Project version');
+    expect(shared?.systemPrompt).toBe('I am project.');
+  });
+
+  it('includes agents from both scopes', async () => {
+    const result = await loadAllAgents(globalMergeDir, projectMergeDir);
+    const names = result.agents.map((a) => a.name);
+    expect(names).toContain('global-only');
+    expect(names).toContain('project-only');
+    expect(names).toContain('shared');
+  });
+
+  it('disabled: true in project suppresses global agent', async () => {
+    const suppressGlobalDir = path.join(TEST_DIR, 'suppress-global');
+    const suppressProjectDir = path.join(TEST_DIR, 'suppress-project');
+    fs.mkdirSync(suppressGlobalDir, { recursive: true });
+    fs.mkdirSync(suppressProjectDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(suppressGlobalDir, 'unwanted.md'),
+      `---
+description: Global agent to suppress
+---
+
+I should be suppressed.`,
+    );
+
+    fs.writeFileSync(
+      path.join(suppressProjectDir, 'unwanted.md'),
+      `---
+description: Global agent to suppress
+disabled: true
+---`,
+    );
+
+    const result = await loadAllAgents(suppressGlobalDir, suppressProjectDir);
+    const unwanted = result.agents.find((a) => a.name === 'unwanted');
+    expect(unwanted).toBeUndefined();
+
+    fs.rmSync(suppressGlobalDir, { recursive: true, force: true });
+    fs.rmSync(suppressProjectDir, { recursive: true, force: true });
+  });
+
+  it('handles nonexistent directories gracefully', async () => {
+    const result = await loadAllAgents(
+      '/nonexistent/global',
+      '/nonexistent/project',
+    );
+    expect(result.agents).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements agent schema definition, markdown frontmatter parsing, and file discovery for user-defined agents.

**Issue:** Closes #105
**Parent:** #28
**Depends on:** Story 1 (#104, merged)

## Changes

### New files
- `src/agent/agents/schema.ts` — `AgentInfoSchema` (Zod), `PermissionConfigSchema`, `ResolvedAgent`, `AgentSource` types
- `src/agent/agents/loader.ts` — `parseAgentMarkdown()`, `loadAgentsFromDirectory()`, `loadAllAgents()`, `getDefaultAgentDirs()`
- `tests/test-agent-loader.ts` — 24 `bun:test` cases across 3 describe blocks

### Modified files
- `src/config/schema.ts` — added `agents` field to `ConfigSchema` (record of named agent definitions)
- `package.json` / `bun.lock` — added `gray-matter` dependency

## Design

- **gray-matter** parses YAML frontmatter; body becomes `systemPrompt`
- **Name resolution**: frontmatter `name` field wins, filename (sans .md) is fallback
- **Discovery**: recursive `**/*.md` glob via Bun's `Glob` API
- **Precedence**: project overrides global for same name; `disabled: true` suppresses
- **Duplicate detection**: warning + skip within same scope
- **Schema validation**: Zod `safeParse` with helpful error messages for invalid files
- **JSON config**: `agents` field in `ConfigSchema` requires `name` (no filename fallback)

## Tests

```
60 pass, 0 fail, 139 expect() calls (both Story 1 + Story 2 suites)
```