### PR TITLE
fix(agent): address code review findings from Stories 1-2

### DIFF
--- a/src/agent/agents/loader.ts
+++ b/src/agent/agents/loader.ts
@@ -8,9 +8,10 @@
 
 import { Glob } from 'bun';
 import matter from 'gray-matter';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { AgentInfoSchema } from './schema';
+import { AgentInfoSchema, AgentNameSchema } from './schema';
 import type { AgentSource, ResolvedAgent } from './schema';
 
 /** Result of loading agents from a single scope. */
@@ -26,18 +27,19 @@ export type LoadWarning = {
 
 /**
  * Parse a single markdown agent file into a ResolvedAgent.
+ * Reads file content asynchronously.
  *
  * @param filePath - Absolute path to the .md file
  * @param source - Where this file was found (global/project)
  * @returns The parsed agent, or a warning if parsing/validation failed
  */
-export function parseAgentFile(
+export async function parseAgentFile(
   filePath: string,
   source: AgentSource,
-): ResolvedAgent | LoadWarning {
+): Promise<ResolvedAgent | LoadWarning> {
   let content: string;
   try {
-    content = require('fs').readFileSync(filePath, 'utf-8');
+    content = await fs.readFile(filePath, 'utf-8');
   } catch {
     return { path: filePath, message: 'Could not read file' };
   }
@@ -71,8 +73,20 @@ export function parseAgentMarkdown(
 
   const info = result.data;
 
-  // Name: frontmatter `name` field, or filename without extension as fallback
-  const name = info.name ?? path.basename(filePath, '.md');
+  // Name: frontmatter `name` field (already validated by schema),
+  // or filename without extension as fallback
+  let name = info.name;
+  if (!name) {
+    const fallback = path.basename(filePath, '.md');
+    const nameResult = AgentNameSchema.safeParse(fallback);
+    if (!nameResult.success) {
+      return {
+        path: filePath,
+        message: `Invalid agent name from filename "${fallback}": must be lowercase alphanumeric with hyphens/underscores`,
+      };
+    }
+    name = nameResult.data;
+  }
 
   return {
     ...info,
@@ -82,10 +96,17 @@ export function parseAgentMarkdown(
   };
 }
 
+/** Extract display path from an AgentSource. */
+function sourceDisplayPath(source: AgentSource): string {
+  return source.type === 'global' || source.type === 'project'
+    ? source.path
+    : 'unknown';
+}
+
 /**
  * Discover and load all agent markdown files from a directory (recursive).
  *
- * @param dir - Directory to scan for `**\/*.md` files
+ * @param dir - Directory to scan for **\/*.md files
  * @param sourceType - "global" or "project"
  * @returns Loaded agents and any warnings
  */
@@ -97,7 +118,6 @@ export async function loadAgentsFromDirectory(
   const warnings: LoadWarning[] = [];
 
   // Check if directory exists
-  const fs = await import('node:fs/promises');
   try {
     await fs.access(dir);
   } catch {
@@ -118,7 +138,7 @@ export async function loadAgentsFromDirectory(
   for (const entry of entries) {
     const filePath = path.join(dir, entry);
     const source: AgentSource = { type: sourceType, path: filePath };
-    const result = parseAgentFile(filePath, source);
+    const result = await parseAgentFile(filePath, source);
 
     if ('message' in result) {
       warnings.push(result);
@@ -134,20 +154,17 @@ export async function loadAgentsFromDirectory(
   for (const agent of agents) {
     const existing = seen.get(agent.name);
     if (existing) {
-      const sourcePath =
-        agent.source.type === 'global' || agent.source.type === 'project'
-          ? agent.source.path
-          : 'unknown';
       warnings.push({
-        path: sourcePath,
-        message: `Duplicate agent name "${agent.name}" (already defined in ${existing})`,
+        path: sourceDisplayPath(agent.source),
+        message:
+          'Duplicate agent name "' +
+          agent.name +
+          '" (already defined in ' +
+          existing +
+          ')',
       });
     } else {
-      const sourcePath =
-        agent.source.type === 'global' || agent.source.type === 'project'
-          ? agent.source.path
-          : 'unknown';
-      seen.set(agent.name, sourcePath);
+      seen.set(agent.name, sourceDisplayPath(agent.source));
       deduped.push(agent);
     }
   }

--- a/src/agent/agents/schema.ts
+++ b/src/agent/agents/schema.ts
@@ -24,10 +24,33 @@ export const PermissionConfigSchema: z.ZodType<PermissionConfig> = z.record(
   PermissionRuleSchema,
 );
 
+// === Agent name validation ===
+
+/**
+ * Agent name format: lowercase alphanumeric with hyphens/underscores.
+ * Must start with alphanumeric. No double underscores (prevents ambiguity
+ * in qualified tool names like `mcp__server__tool`).
+ *
+ * Matches the same pattern as McpServerNameSchema in config/schema.ts.
+ */
+export const AgentNameSchema = z
+  .string()
+  .regex(
+    /^[a-z0-9][a-z0-9_-]*$/,
+    'Agent name must start with alphanumeric, contain only lowercase alphanumeric, hyphens, or underscores',
+  )
+  .refine((s) => !s.includes('__'), {
+    message: 'Agent name must not contain "__" (double underscore)',
+  });
+
 // === Max iterations ===
 
 const MaxIterationsPresetSchema = z.enum(['quick', 'medium', 'thorough']);
 
+/**
+ * Numeric values for iteration presets. Single source of truth — also used
+ * by IterationLimitsObjectSchema in config/schema.ts.
+ */
 export const ITERATION_PRESETS = {
   quick: 8,
   medium: 15,
@@ -43,11 +66,47 @@ const MaxIterationsSchema = z.union([
 
 export const AgentModeSchema = z.enum(['primary', 'subagent', 'all']);
 
+// === Permission key to tool name mapping ===
+
+/**
+ * Maps permission keys (as used in agent configs) to actual tool names
+ * (as registered in the tool system). Used by Story 4's mode refactor
+ * to translate permission evaluations to tool filtering.
+ *
+ * Unknown keys fall through — future tools work without schema changes.
+ */
+export const PERMISSION_KEY_TO_TOOLS: Record<string, readonly string[]> = {
+  read: ['read_file'],
+  edit: ['edit_file', 'write_file'],
+  glob: ['glob'],
+  grep: ['grep'],
+  list: ['list_dir'],
+  bash: ['run_command'],
+  task: ['task'],
+  todo: ['todo_write', 'todo_read'],
+  web_fetch: ['web_fetch'],
+  // 'mcp' and '*' are handled specially — not in this map
+};
+
+/**
+ * Reverse mapping: tool name → permission key.
+ * Built from PERMISSION_KEY_TO_TOOLS at module load.
+ */
+export const TOOL_TO_PERMISSION_KEY: Record<string, string> = {};
+for (const [key, tools] of Object.entries(PERMISSION_KEY_TO_TOOLS)) {
+  for (const tool of tools) {
+    TOOL_TO_PERMISSION_KEY[tool] = key;
+  }
+}
+
 // === Agent definition schema ===
 
 const AgentInfoObjectSchema = z.object({
-  /** Agent name. Required in JSON config; optional in markdown (filename fallback). */
-  name: z.string().optional(),
+  /**
+   * Agent name. Optional in markdown (filename is fallback).
+   * When present, must match the agent name format.
+   */
+  name: AgentNameSchema.optional(),
   /** Description shown in task tool dynamic listing. Required. */
   description: z.string(),
   /** Whether this agent can be used as primary, subagent, or both. */
@@ -74,7 +133,11 @@ export type AgentInfoInput = z.input<typeof AgentInfoSchema>;
 
 // === Resolved agent (fully loaded with source metadata) ===
 
-export type ResolvedAgent = AgentInfo & {
+/**
+ * Fully resolved agent with required name, system prompt, and source.
+ * Uses Omit to explicitly narrow `name` from optional to required.
+ */
+export type ResolvedAgent = Omit<AgentInfo, 'name'> & {
   /** Canonical agent name (from frontmatter `name` field or filename fallback). */
   name: string;
   /** System prompt (markdown body for file-based agents, empty for JSON-only). */

--- a/src/agent/permission/index.ts
+++ b/src/agent/permission/index.ts
@@ -130,10 +130,20 @@ export function merge(...rulesets: PermissionRuleset[]): PermissionRuleset {
  * (pattern: "*") in the ruleset. Useful for reporting which tools an agent
  * cannot use at all.
  *
+ * Accounts for the wildcard permission key "*": if "*" is denied and a
+ * specific key has no explicit wildcard-pattern override, that key is
+ * considered disabled too.
+ *
  * Only considers rules with pattern "*" — specific pattern overrides
  * are not included (the tool isn't fully disabled if some patterns are allowed).
+ *
+ * @param ruleset - The permission ruleset to analyze
+ * @param knownKeys - Optional set of known permission keys to expand "*" deny across
  */
-export function disabled(ruleset: PermissionRuleset): Set<string> {
+export function disabled(
+  ruleset: PermissionRuleset,
+  knownKeys?: readonly string[],
+): Set<string> {
   const result = new Set<string>();
 
   // Track the last wildcard-pattern action per permission key
@@ -145,9 +155,21 @@ export function disabled(ruleset: PermissionRuleset): Set<string> {
     }
   }
 
+  // Check if the universal wildcard "*" is denied
+  const wildcardDenied = lastWildcard.get('*') === 'deny';
+
   for (const [permission, action] of lastWildcard) {
     if (action === 'deny') {
       result.add(permission);
+    }
+  }
+
+  // If "*" is denied, propagate to known keys that don't have an explicit override
+  if (wildcardDenied && knownKeys) {
+    for (const key of knownKeys) {
+      if (!lastWildcard.has(key)) {
+        result.add(key);
+      }
     }
   }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -9,7 +9,11 @@
 
 import { z } from 'zod';
 
-import { AgentInfoSchema } from '../agent/agents/schema';
+import {
+  AgentInfoSchema,
+  AgentNameSchema,
+  ITERATION_PRESETS,
+} from '../agent/agents/schema';
 
 // === Shared enums ===
 
@@ -105,9 +109,9 @@ const RunCommandToolObjectSchema = z.object({
 });
 
 const IterationLimitsObjectSchema = z.object({
-  quick: z.number().int().min(1).default(8),
-  medium: z.number().int().min(1).default(15),
-  thorough: z.number().int().min(1).default(25),
+  quick: z.number().int().min(1).default(ITERATION_PRESETS.quick),
+  medium: z.number().int().min(1).default(ITERATION_PRESETS.medium),
+  thorough: z.number().int().min(1).default(ITERATION_PRESETS.thorough),
 });
 
 const TaskToolObjectSchema = z.object({
@@ -275,9 +279,9 @@ export const ConfigSchema = z.object({
 
   mcp: z.record(McpServerNameSchema, McpServerConfigSchema).default({}),
 
-  agents: z
-    .record(z.string(), AgentInfoSchema.extend({ name: z.string() }))
-    .default({}),
+  // Agent definitions from JSON config. The record key IS the agent name —
+  // any `name` field inside the value is ignored (key takes precedence).
+  agents: z.record(AgentNameSchema, AgentInfoSchema).default({}),
 
   instructions: z.array(z.string()).default([]),
 

--- a/tests/test-agent-loader.ts
+++ b/tests/test-agent-loader.ts
@@ -302,6 +302,72 @@ description: No body
     expect(result.systemPrompt).toBe('');
   });
 
+  it('rejects invalid frontmatter name format', () => {
+    const content = `---
+name: Invalid Name
+description: Bad name
+---
+
+Bad.`;
+
+    const result = parseAgentMarkdown(content, '/agents/bad.md', projectSource);
+    expect(isWarning(result)).toBe(true);
+    if (!isWarning(result)) return;
+
+    expect(result.message).toContain('Schema validation failed');
+  });
+
+  it('rejects __proto__ as frontmatter name', () => {
+    const content = `---
+name: __proto__
+description: Sneaky
+---
+
+Sneaky.`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/sneaky.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(true);
+  });
+
+  it('rejects empty string frontmatter name', () => {
+    const content = `---
+name: ""
+description: Empty name
+---
+
+Empty.`;
+
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/empty.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(true);
+  });
+
+  it('validates filename fallback against name format', () => {
+    const content = `---
+description: No name field
+---
+
+Body.`;
+
+    // Uppercase filename — should fail name validation
+    const result = parseAgentMarkdown(
+      content,
+      '/agents/BadName.md',
+      projectSource,
+    );
+    expect(isWarning(result)).toBe(true);
+    if (!isWarning(result)) return;
+
+    expect(result.message).toContain('Invalid agent name from filename');
+  });
+
   it('preserves source metadata', () => {
     const content = `---
 description: Source test
@@ -325,7 +391,7 @@ Body.`;
   });
 });
 
-// ─── loadAgentsFromDirectory (filesystem tests) ─────────────────────��
+// ─── loadAgentsFromDirectory (filesystem tests) ─────────────────────
 
 describe('loadAgentsFromDirectory', () => {
   beforeAll(() => {

--- a/tests/test-permissions.ts
+++ b/tests/test-permissions.ts
@@ -188,6 +188,19 @@ describe('evaluate', () => {
     expect(evaluate('task', 'reviewer', ruleset)).toBe('deny');
   });
 
+  it('handles empty string input', () => {
+    const ruleset = fromConfig({ bash: { '*': 'deny' } });
+    expect(evaluate('bash', '', ruleset)).toBe('deny');
+  });
+
+  it('handles regex metacharacters in patterns', () => {
+    const ruleset = fromConfig({
+      bash: { '*': 'deny', 'echo (hello)': 'allow' },
+    });
+    expect(evaluate('bash', 'echo (hello)', ruleset)).toBe('allow');
+    expect(evaluate('bash', 'echo hello', ruleset)).toBe('deny');
+  });
+
   it('mcp qualified name patterns', () => {
     const ruleset = fromConfig({
       mcp: { '*': 'deny', 'mcp__github__*': 'allow' },
@@ -308,6 +321,40 @@ describe('disabled', () => {
     expect(result.has('read')).toBe(false);
     expect(result.has('glob')).toBe(false);
     expect(result.has('grep')).toBe(false);
+  });
+
+  it('propagates wildcard deny to known keys without explicit override', () => {
+    const ruleset = fromConfig({
+      '*': 'deny',
+      read: 'allow',
+    });
+    const knownKeys = ['read', 'edit', 'bash', 'glob'];
+    const result = disabled(ruleset, knownKeys);
+    // read has explicit allow — not disabled
+    expect(result.has('read')).toBe(false);
+    // edit, bash, glob have no override — disabled via wildcard
+    expect(result.has('edit')).toBe(true);
+    expect(result.has('bash')).toBe(true);
+    expect(result.has('glob')).toBe(true);
+    // * itself is disabled
+    expect(result.has('*')).toBe(true);
+  });
+
+  it('does not propagate when wildcard is not denied', () => {
+    const ruleset = fromConfig({ '*': 'allow', edit: 'deny' });
+    const knownKeys = ['read', 'edit', 'bash'];
+    const result = disabled(ruleset, knownKeys);
+    expect(result.has('edit')).toBe(true);
+    expect(result.has('read')).toBe(false);
+    expect(result.has('bash')).toBe(false);
+  });
+
+  it('without knownKeys, behaves as before (no propagation)', () => {
+    const ruleset = fromConfig({ '*': 'deny' });
+    const result = disabled(ruleset);
+    expect(result.has('*')).toBe(true);
+    // Without knownKeys, edit is not in the result
+    expect(result.has('edit')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses all actionable findings from code-reviewer and architect-reviewer runs against Stories 1-2.

## Security fixes
- **Agent name validation** — `AgentNameSchema` with regex `^[a-z0-9][a-z0-9_-]*$`, no `__`. Applied to frontmatter `name` field, filename fallback, and JSON config record keys.
- **Config record keys validated** — uses `AgentNameSchema` (matches `McpServerNameSchema` pattern)

## Bug fixes
- **`disabled()` wildcard propagation** — now accepts optional `knownKeys` param; when `"*": "deny"` is set, propagates to known keys without explicit override
- **JSON config name conflict** — record key IS the name now; removed redundant `.extend({ name: z.string() })`

## Style fixes
- Replaced `require('fs').readFileSync` with top-level `import fs from 'node:fs/promises'`
- Made `parseAgentFile` async (was sync I/O in async pipeline)
- Extracted `sourceDisplayPath()` helper
- Fixed JSDoc glob pattern and broken Unicode in test comment

## Design improvements
- Added `PERMISSION_KEY_TO_TOOLS` and `TOOL_TO_PERMISSION_KEY` mappings for Story 4
- Deduplicated `ITERATION_PRESETS` — config schema now imports from agent schema
- Used `Omit<AgentInfo, 'name'>` for explicit type narrowing in `ResolvedAgent`

## Tests
```
69 pass, 0 fail, 158 expect() calls (up from 60 tests)
```

9 new tests: `disabled()` propagation (3), name validation (4), edge cases (2)