### PR TITLE
feat: Agent Registry + Built-in Agents (Story 3) #106

### DIFF
--- a/src/agent/agents/builtins.ts
+++ b/src/agent/agents/builtins.ts
@@ -1,0 +1,94 @@
+/**
+ * Built-in agent definitions.
+ *
+ * Expresses the existing `build`, `plan`, and `explore` modes as agent
+ * definitions in the unified agent model. These are registered first in the
+ * merging pipeline — user-defined agents (global/project/config) can override
+ * or extend them.
+ *
+ * System prompts are NOT inlined here — they stay in their existing prompt
+ * builder functions. The `systemPrompt` field is left empty; the prompt
+ * system resolves it at runtime via the prompt builders (Story 4 will wire
+ * this up). This avoids duplicating the prompt content and keeps the
+ * prompt-builder context injection working.
+ */
+
+import type { PermissionConfig } from '../permission/types';
+import type { ResolvedAgent } from './schema';
+
+// === Permission configs for built-in agents ===
+
+/**
+ * Build agent: full access (current default behavior).
+ */
+const BUILD_PERMISSIONS: PermissionConfig = {
+  '*': 'allow',
+};
+
+/**
+ * Plan agent: read-only — deny edit tools (current plan mode behavior).
+ * run_command is allowed but filtered by the safety layer's
+ * PLAN_MODE_ALLOWED_COMMANDS whitelist at runtime.
+ */
+const PLAN_PERMISSIONS: PermissionConfig = {
+  edit: 'deny',
+};
+
+/**
+ * Explore agent: restricted to read-only tools + bash + web_fetch.
+ * Matches the current explore subagent tool set from MODE_TOOLS.plan
+ * plus web_fetch.
+ */
+const EXPLORE_PERMISSIONS: PermissionConfig = {
+  '*': 'deny',
+  read: 'allow',
+  glob: 'allow',
+  grep: 'allow',
+  list: 'allow',
+  bash: 'allow',
+  web_fetch: 'allow',
+  todo: 'allow',
+};
+
+// === Built-in agent definitions ===
+
+export const BUILTIN_BUILD_AGENT: ResolvedAgent = {
+  name: 'build',
+  description: 'Full-power implementation mode with all tools available',
+  mode: 'primary',
+  disabled: false,
+  permission: BUILD_PERMISSIONS,
+  systemPrompt: '',
+  source: { type: 'builtin' },
+};
+
+export const BUILTIN_PLAN_AGENT: ResolvedAgent = {
+  name: 'plan',
+  description: 'Read-only research and planning mode',
+  mode: 'primary',
+  disabled: false,
+  permission: PLAN_PERMISSIONS,
+  systemPrompt: '',
+  source: { type: 'builtin' },
+};
+
+export const BUILTIN_EXPLORE_AGENT: ResolvedAgent = {
+  name: 'explore',
+  description: 'Fast codebase search specialist for targeted exploration',
+  mode: 'subagent',
+  disabled: false,
+  maxIterations: 'medium',
+  permission: EXPLORE_PERMISSIONS,
+  systemPrompt: '',
+  source: { type: 'builtin' },
+};
+
+/**
+ * All built-in agents in registration order.
+ * Order matters for display — alphabetical within each mode.
+ */
+export const BUILTIN_AGENTS: readonly ResolvedAgent[] = [
+  BUILTIN_BUILD_AGENT,
+  BUILTIN_PLAN_AGENT,
+  BUILTIN_EXPLORE_AGENT,
+];

--- a/src/agent/agents/index.ts
+++ b/src/agent/agents/index.ts
@@ -1,0 +1,145 @@
+/**
+ * Agent system public API.
+ *
+ * Re-exports the registry, built-ins, loader, and schema types.
+ * Provides the `buildAgentRegistry()` function that runs the full
+ * merging pipeline: built-in -> global files -> project files -> JSON config.
+ */
+
+export { AgentRegistry } from './registry';
+export type { AgentListFilter } from './registry';
+
+export {
+  BUILTIN_AGENTS,
+  BUILTIN_BUILD_AGENT,
+  BUILTIN_EXPLORE_AGENT,
+  BUILTIN_PLAN_AGENT,
+} from './builtins';
+
+export {
+  AgentInfoSchema,
+  AgentModeSchema,
+  AgentNameSchema,
+  ITERATION_PRESETS,
+  PERMISSION_KEY_TO_TOOLS,
+  TOOL_TO_PERMISSION_KEY,
+  PermissionConfigSchema,
+} from './schema';
+
+export type {
+  AgentInfo,
+  AgentInfoInput,
+  AgentSource,
+  ResolvedAgent,
+} from './schema';
+
+export {
+  getDefaultAgentDirs,
+  loadAgentsFromDirectory,
+  loadAllAgents,
+  parseAgentFile,
+  parseAgentMarkdown,
+} from './loader';
+export type { LoadResult, LoadWarning } from './loader';
+
+import { AgentNameSchema } from './schema';
+import type { AgentInfo, ResolvedAgent } from './schema';
+import { BUILTIN_AGENTS } from './builtins';
+import { loadAgentsFromDirectory } from './loader';
+import type { LoadWarning } from './loader';
+import { AgentRegistry } from './registry';
+
+/** Options for building the agent registry. */
+export type BuildRegistryOptions = {
+  /** Global agents directory (default: ~/.config/ollie/agents/) */
+  globalDir: string;
+  /** Project agents directory (default: .ollie/agents/) */
+  projectDir: string;
+  /** Agents from JSON config (`agents` field in ollie.json) */
+  configAgents?: Record<string, AgentInfo>;
+};
+
+/** Result of building the agent registry. */
+export type BuildRegistryResult = {
+  registry: AgentRegistry;
+  warnings: LoadWarning[];
+};
+
+/**
+ * Build the agent registry by running the full merging pipeline.
+ *
+ * Pipeline order (later entries override earlier for the same name):
+ * 1. Built-in agents (build, plan, explore)
+ * 2. Global markdown files (~/.config/ollie/agents/)
+ * 3. Project markdown files (.ollie/agents/)
+ * 4. JSON config agents (ollie.json `agents` field)
+ *
+ * Disabled agents are filtered out at the end.
+ */
+export async function buildAgentRegistry(
+  options: BuildRegistryOptions,
+): Promise<BuildRegistryResult> {
+  const warnings: LoadWarning[] = [];
+
+  // Step 1: Start with built-in agents
+  const agentMap = new Map<string, ResolvedAgent>();
+  for (const agent of BUILTIN_AGENTS) {
+    agentMap.set(agent.name, agent);
+  }
+
+  // Step 2+3: Load global and project files separately so disabled agents
+  // can override built-ins (loadAllAgents filters disabled too early).
+  const [globalResult, projectResult] = await Promise.all([
+    loadAgentsFromDirectory(options.globalDir, 'global'),
+    loadAgentsFromDirectory(options.projectDir, 'project'),
+  ]);
+  warnings.push(...globalResult.warnings, ...projectResult.warnings);
+
+  // Global overrides built-in, project overrides global
+  for (const agent of globalResult.agents) {
+    agentMap.set(agent.name, agent);
+  }
+  for (const agent of projectResult.agents) {
+    agentMap.set(agent.name, agent);
+  }
+
+  // Step 4: JSON config agents (highest precedence for same name)
+  if (options.configAgents) {
+    for (const [key, info] of Object.entries(options.configAgents)) {
+      // Validate the config key as an agent name
+      const nameResult = AgentNameSchema.safeParse(key);
+      if (!nameResult.success) {
+        warnings.push({
+          path: 'config',
+          message:
+            'Invalid agent name "' +
+            key +
+            '" in config: ' +
+            nameResult.error.issues.map((i) => i.message).join('; '),
+        });
+        continue;
+      }
+
+      const resolved: ResolvedAgent = {
+        ...info,
+        name: key,
+        systemPrompt: '',
+        source: { type: 'config' },
+      };
+      agentMap.set(key, resolved);
+    }
+  }
+
+  // Filter out disabled agents
+  const agents: ResolvedAgent[] = [];
+  for (const agent of agentMap.values()) {
+    if (!agent.disabled) {
+      agents.push(agent);
+    }
+  }
+
+  return {
+    registry: new AgentRegistry(agents),
+    warnings,
+  };
+}

--- a/src/agent/agents/registry.ts
+++ b/src/agent/agents/registry.ts
@@ -1,0 +1,102 @@
+/**
+ * Agent registry — central store for all resolved agent definitions.
+ *
+ * Holds built-in + user-defined agents after the merging pipeline runs.
+ * Provides lookup by name, filtered listing, and permission-aware subagent
+ * listing for the task tool.
+ */
+
+import { fromConfig, evaluate } from '../permission/index';
+import type { PermissionConfig } from '../permission/types';
+import type { ResolvedAgent } from './schema';
+
+/** Filter options for listing agents. */
+export type AgentListFilter = {
+  /** Only include agents with this mode (or 'all' mode agents). */
+  mode?: 'primary' | 'subagent';
+};
+
+/**
+ * Immutable agent registry.
+ *
+ * Created once during config resolution, then shared across the session.
+ * Use `createRegistry()` to build one from the merging pipeline output.
+ */
+export class AgentRegistry {
+  private readonly agents: ReadonlyMap<string, ResolvedAgent>;
+
+  constructor(agents: readonly ResolvedAgent[]) {
+    const map = new Map<string, ResolvedAgent>();
+    for (const agent of agents) {
+      map.set(agent.name, agent);
+    }
+    this.agents = map;
+  }
+
+  /**
+   * Look up an agent by name.
+   * Returns undefined if not found.
+   */
+  get(name: string): ResolvedAgent | undefined {
+    return this.agents.get(name);
+  }
+
+  /**
+   * List all registered agents, optionally filtered by mode.
+   *
+   * When filtering by mode, agents with `mode: 'all'` are always included.
+   * Results are sorted alphabetically by name.
+   */
+  list(filter?: AgentListFilter): ResolvedAgent[] {
+    const result: ResolvedAgent[] = [];
+
+    for (const agent of this.agents.values()) {
+      if (filter?.mode) {
+        if (agent.mode !== filter.mode && agent.mode !== 'all') {
+          continue;
+        }
+      }
+      result.push(agent);
+    }
+
+    return result.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  /**
+   * List agents available for task delegation from a calling agent.
+   *
+   * Filters to subagent-mode (or 'all') agents that the caller is permitted
+   * to invoke via its `task` permission key. Uses the caller's permission
+   * config to evaluate `task` permission for each agent name.
+   *
+   * @param callerPermission - The calling agent's permission config (undefined = no restrictions)
+   * @returns Agents the caller can delegate to, sorted alphabetically
+   */
+  listForTask(callerPermission?: PermissionConfig): ResolvedAgent[] {
+    const subagents = this.list({ mode: 'subagent' });
+
+    if (!callerPermission) {
+      // No permission config = default allow = can invoke any subagent
+      return subagents;
+    }
+
+    const ruleset = fromConfig(callerPermission);
+
+    return subagents.filter((agent) => {
+      // Agent name is used as the pattern-matched input — permission rules
+      // like `task: { '*': 'deny', 'explore': 'allow' }` match against it.
+      const action = evaluate('task', agent.name, ruleset);
+      return action !== 'deny';
+    });
+  }
+
+  /** Number of registered agents. */
+  get size(): number {
+    return this.agents.size;
+  }
+
+  /** Check if an agent name is registered. */
+  has(name: string): boolean {
+    return this.agents.has(name);
+  }
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -24,6 +24,7 @@ export type { ToolPermissionMap, TuiConfig } from './resolve';
 export {
   deriveSubagentConfig,
   extractAgentConfig,
+  extractAgentRegistry,
   extractCompactionConfig,
   extractSafetyConfig,
   extractToolsConfig,

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -6,6 +6,8 @@
  * ResolvedConfig for each layer.
  */
 
+import { buildAgentRegistry, getDefaultAgentDirs } from '../agent/agents/index';
+import type { BuildRegistryResult } from '../agent/agents/index';
 import type { CompactionConfig } from '../agent/compaction';
 import type { McpToolInfo } from '../agent/mcp/types';
 import type { SafetyConfig } from '../agent/safety/types';
@@ -272,4 +274,29 @@ export function deriveSubagentConfig(
       maxIterations: overrides.maxIterations ?? baseConfig.agent.maxIterations,
     },
   };
+}
+
+/**
+ * Build the agent registry from resolved config.
+ *
+ * Runs the full merging pipeline:
+ * 1. Built-in agents (build, plan, explore)
+ * 2. Global markdown files (~/.config/ollie/agents/)
+ * 3. Project markdown files (.ollie/agents/)
+ * 4. JSON config agents (ollie.json `agents` field)
+ *
+ * @param config - The resolved config (provides JSON-defined agents)
+ * @param projectRoot - Project root directory (for .ollie/agents/ discovery)
+ */
+export async function extractAgentRegistry(
+  config: ResolvedConfig,
+  projectRoot: string,
+): Promise<BuildRegistryResult> {
+  const { globalDir, projectDir } = getDefaultAgentDirs(projectRoot);
+
+  return buildAgentRegistry({
+    globalDir,
+    projectDir,
+    configAgents: config.agents,
+  });
 }

--- a/tests/test-agent-registry.ts
+++ b/tests/test-agent-registry.ts
@@ -1,0 +1,520 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { AgentRegistry } from '../src/agent/agents/registry';
+import {
+  BUILTIN_AGENTS,
+  BUILTIN_BUILD_AGENT,
+  BUILTIN_EXPLORE_AGENT,
+  BUILTIN_PLAN_AGENT,
+  buildAgentRegistry,
+} from '../src/agent/agents/index';
+import type { ResolvedAgent } from '../src/agent/agents/schema';
+import type { PermissionConfig } from '../src/agent/permission/types';
+
+// ─── Test helpers ─────────────────────────────────────────────────────
+
+function makeAgent(
+  overrides: Partial<ResolvedAgent> & { name: string },
+): ResolvedAgent {
+  return {
+    description: 'Test agent',
+    mode: 'subagent',
+    disabled: false,
+    systemPrompt: '',
+    source: { type: 'builtin' },
+    ...overrides,
+  };
+}
+
+// ─── Built-in agents ──────────────────────────────────────────────────
+
+describe('Built-in agents', () => {
+  it('defines three built-in agents', () => {
+    expect(BUILTIN_AGENTS).toHaveLength(3);
+  });
+
+  it('build agent has correct properties', () => {
+    expect(BUILTIN_BUILD_AGENT.name).toBe('build');
+    expect(BUILTIN_BUILD_AGENT.mode).toBe('primary');
+    expect(BUILTIN_BUILD_AGENT.permission).toEqual({ '*': 'allow' });
+    expect(BUILTIN_BUILD_AGENT.source).toEqual({ type: 'builtin' });
+    expect(BUILTIN_BUILD_AGENT.disabled).toBe(false);
+  });
+
+  it('plan agent has correct properties', () => {
+    expect(BUILTIN_PLAN_AGENT.name).toBe('plan');
+    expect(BUILTIN_PLAN_AGENT.mode).toBe('primary');
+    expect(BUILTIN_PLAN_AGENT.permission).toEqual({ edit: 'deny' });
+    expect(BUILTIN_PLAN_AGENT.source).toEqual({ type: 'builtin' });
+  });
+
+  it('explore agent has correct properties', () => {
+    expect(BUILTIN_EXPLORE_AGENT.name).toBe('explore');
+    expect(BUILTIN_EXPLORE_AGENT.mode).toBe('subagent');
+    expect(BUILTIN_EXPLORE_AGENT.maxIterations).toBe('medium');
+    expect(BUILTIN_EXPLORE_AGENT.permission).toBeDefined();
+    expect(BUILTIN_EXPLORE_AGENT.permission!['*']).toBe('deny');
+    expect(BUILTIN_EXPLORE_AGENT.permission!['read']).toBe('allow');
+    expect(BUILTIN_EXPLORE_AGENT.source).toEqual({ type: 'builtin' });
+  });
+});
+
+// ─── AgentRegistry ────────────────────────────────────────────────────
+
+describe('AgentRegistry', () => {
+  describe('constructor and basic operations', () => {
+    it('creates empty registry', () => {
+      const registry = new AgentRegistry([]);
+      expect(registry.size).toBe(0);
+    });
+
+    it('creates registry from agent array', () => {
+      const registry = new AgentRegistry(BUILTIN_AGENTS);
+      expect(registry.size).toBe(3);
+    });
+
+    it('deduplicates agents by name (last wins)', () => {
+      const agent1 = makeAgent({ name: 'test', description: 'First' });
+      const agent2 = makeAgent({ name: 'test', description: 'Second' });
+      const registry = new AgentRegistry([agent1, agent2]);
+      expect(registry.size).toBe(1);
+      expect(registry.get('test')?.description).toBe('Second');
+    });
+  });
+
+  describe('get()', () => {
+    const registry = new AgentRegistry(BUILTIN_AGENTS);
+
+    it('returns agent by name', () => {
+      const agent = registry.get('build');
+      expect(agent).toBeDefined();
+      expect(agent?.name).toBe('build');
+    });
+
+    it('returns undefined for unknown name', () => {
+      expect(registry.get('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('has()', () => {
+    const registry = new AgentRegistry(BUILTIN_AGENTS);
+
+    it('returns true for registered agent', () => {
+      expect(registry.has('build')).toBe(true);
+      expect(registry.has('plan')).toBe(true);
+      expect(registry.has('explore')).toBe(true);
+    });
+
+    it('returns false for unregistered agent', () => {
+      expect(registry.has('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('list()', () => {
+    const agents = [
+      ...BUILTIN_AGENTS,
+      makeAgent({ name: 'reviewer', mode: 'subagent' }),
+      makeAgent({ name: 'analyzer', mode: 'all' }),
+    ];
+    const registry = new AgentRegistry(agents);
+
+    it('lists all agents sorted alphabetically', () => {
+      const all = registry.list();
+      expect(all.map((a) => a.name)).toEqual([
+        'analyzer',
+        'build',
+        'explore',
+        'plan',
+        'reviewer',
+      ]);
+    });
+
+    it('filters by primary mode', () => {
+      const primary = registry.list({ mode: 'primary' });
+      const names = primary.map((a) => a.name);
+      expect(names).toContain('build');
+      expect(names).toContain('plan');
+      expect(names).toContain('analyzer'); // mode: 'all' included
+      expect(names).not.toContain('explore');
+      expect(names).not.toContain('reviewer');
+    });
+
+    it('filters by subagent mode', () => {
+      const subagents = registry.list({ mode: 'subagent' });
+      const names = subagents.map((a) => a.name);
+      expect(names).toContain('explore');
+      expect(names).toContain('reviewer');
+      expect(names).toContain('analyzer'); // mode: 'all' included
+      expect(names).not.toContain('build');
+      expect(names).not.toContain('plan');
+    });
+
+    it('returns empty array when no agents match filter', () => {
+      const emptyRegistry = new AgentRegistry([
+        makeAgent({ name: 'primary-only', mode: 'primary' }),
+      ]);
+      const subagents = emptyRegistry.list({ mode: 'subagent' });
+      expect(subagents).toEqual([]);
+    });
+  });
+
+  describe('listForTask()', () => {
+    const agents = [
+      ...BUILTIN_AGENTS,
+      makeAgent({ name: 'reviewer', mode: 'subagent' }),
+      makeAgent({ name: 'deployer', mode: 'subagent' }),
+    ];
+    const registry = new AgentRegistry(agents);
+
+    it('returns all subagents when no caller permission', () => {
+      const available = registry.listForTask();
+      const names = available.map((a) => a.name);
+      expect(names).toContain('explore');
+      expect(names).toContain('reviewer');
+      expect(names).toContain('deployer');
+      // Primary agents excluded
+      expect(names).not.toContain('build');
+      expect(names).not.toContain('plan');
+    });
+
+    it('returns all subagents when caller has no task restriction', () => {
+      const permission: PermissionConfig = { '*': 'allow' };
+      const available = registry.listForTask(permission);
+      expect(available.map((a) => a.name)).toContain('explore');
+      expect(available.map((a) => a.name)).toContain('reviewer');
+    });
+
+    it('filters subagents by task permission (deny all, allow specific)', () => {
+      const permission: PermissionConfig = {
+        '*': 'deny',
+        task: { '*': 'deny', explore: 'allow' },
+      };
+      const available = registry.listForTask(permission);
+      const names = available.map((a) => a.name);
+      expect(names).toEqual(['explore']);
+    });
+
+    it('denies all subagents when task is fully denied', () => {
+      const permission: PermissionConfig = {
+        task: 'deny',
+      };
+      const available = registry.listForTask(permission);
+      expect(available).toEqual([]);
+    });
+
+    it('allows subagents matching glob pattern', () => {
+      const permission: PermissionConfig = {
+        task: { '*': 'deny', 'review*': 'allow', explore: 'allow' },
+      };
+      const available = registry.listForTask(permission);
+      const names = available.map((a) => a.name);
+      expect(names).toContain('reviewer');
+      expect(names).toContain('explore');
+      expect(names).not.toContain('deployer');
+    });
+
+    it('ask permission is not denied (agent is listed)', () => {
+      const permission: PermissionConfig = {
+        task: 'ask',
+      };
+      const available = registry.listForTask(permission);
+      expect(available.length).toBeGreaterThan(0);
+    });
+
+    it('includes mode: "all" agents in task listing', () => {
+      const withAll = new AgentRegistry([
+        ...BUILTIN_AGENTS,
+        makeAgent({ name: 'helper', mode: 'all' }),
+      ]);
+      const available = withAll.listForTask();
+      const names = available.map((a) => a.name);
+      expect(names).toContain('explore'); // subagent
+      expect(names).toContain('helper'); // mode: 'all'
+      expect(names).not.toContain('build'); // primary only
+    });
+
+    it('results are sorted alphabetically', () => {
+      const available = registry.listForTask();
+      const names = available.map((a) => a.name);
+      const sorted = [...names].sort();
+      expect(names).toEqual(sorted);
+    });
+  });
+});
+
+// ─── buildAgentRegistry (integration) ─────────────────────────────────
+
+const TEST_DIR = path.join(import.meta.dir, '.test-registry-agents');
+const GLOBAL_DIR = path.join(TEST_DIR, 'global');
+const PROJECT_DIR = path.join(TEST_DIR, 'project');
+
+describe('buildAgentRegistry', () => {
+  beforeAll(() => {
+    fs.mkdirSync(GLOBAL_DIR, { recursive: true });
+    fs.mkdirSync(PROJECT_DIR, { recursive: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('includes built-in agents with no files or config', async () => {
+    const emptyGlobal = path.join(TEST_DIR, 'empty-global');
+    const emptyProject = path.join(TEST_DIR, 'empty-project');
+
+    const { registry, warnings } = await buildAgentRegistry({
+      globalDir: emptyGlobal,
+      projectDir: emptyProject,
+    });
+
+    expect(warnings).toEqual([]);
+    expect(registry.size).toBe(3);
+    expect(registry.has('build')).toBe(true);
+    expect(registry.has('plan')).toBe(true);
+    expect(registry.has('explore')).toBe(true);
+  });
+
+  it('adds user-defined agents from markdown files', async () => {
+    const dir = path.join(TEST_DIR, 'user-agents');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'reviewer.md'),
+      `---
+description: Reviews code
+mode: subagent
+---
+
+You are a code reviewer.`,
+    );
+
+    const { registry } = await buildAgentRegistry({
+      globalDir: path.join(TEST_DIR, 'nonexistent'),
+      projectDir: dir,
+    });
+
+    expect(registry.size).toBe(4); // 3 built-in + 1 user
+    expect(registry.has('reviewer')).toBe(true);
+    expect(registry.get('reviewer')?.description).toBe('Reviews code');
+  });
+
+  it('project file overrides built-in agent', async () => {
+    const dir = path.join(TEST_DIR, 'override-builtin');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'explore.md'),
+      `---
+description: Custom explore agent
+mode: subagent
+maxIterations: 30
+---
+
+You are a custom explore agent.`,
+    );
+
+    const { registry } = await buildAgentRegistry({
+      globalDir: path.join(TEST_DIR, 'nonexistent'),
+      projectDir: dir,
+    });
+
+    expect(registry.size).toBe(3);
+    const explore = registry.get('explore');
+    expect(explore?.description).toBe('Custom explore agent');
+    expect(explore?.maxIterations).toBe(30);
+    expect(explore?.source.type).toBe('project');
+  });
+
+  it('global file overrides built-in, project overrides global', async () => {
+    const globalDir = path.join(TEST_DIR, 'precedence-global');
+    const projectDir = path.join(TEST_DIR, 'precedence-project');
+    fs.mkdirSync(globalDir, { recursive: true });
+    fs.mkdirSync(projectDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(globalDir, 'explore.md'),
+      `---
+description: Global explore
+mode: subagent
+---
+
+Global explore prompt.`,
+    );
+
+    fs.writeFileSync(
+      path.join(projectDir, 'explore.md'),
+      `---
+description: Project explore
+mode: subagent
+---
+
+Project explore prompt.`,
+    );
+
+    const { registry } = await buildAgentRegistry({
+      globalDir,
+      projectDir,
+    });
+
+    const explore = registry.get('explore');
+    expect(explore?.description).toBe('Project explore');
+    expect(explore?.source.type).toBe('project');
+  });
+
+  it('JSON config agents override file-based agents', async () => {
+    const dir = path.join(TEST_DIR, 'config-override');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'reviewer.md'),
+      `---
+description: File reviewer
+mode: subagent
+---
+
+File reviewer prompt.`,
+    );
+
+    const { registry } = await buildAgentRegistry({
+      globalDir: path.join(TEST_DIR, 'nonexistent'),
+      projectDir: dir,
+      configAgents: {
+        reviewer: {
+          description: 'Config reviewer',
+          mode: 'subagent',
+          disabled: false,
+        },
+      },
+    });
+
+    const reviewer = registry.get('reviewer');
+    expect(reviewer?.description).toBe('Config reviewer');
+    expect(reviewer?.source.type).toBe('config');
+  });
+
+  it('disabled agent in config suppresses built-in', async () => {
+    const { registry } = await buildAgentRegistry({
+      globalDir: path.join(TEST_DIR, 'nonexistent'),
+      projectDir: path.join(TEST_DIR, 'nonexistent'),
+      configAgents: {
+        explore: {
+          description: 'Disabled explore',
+          mode: 'subagent',
+          disabled: true,
+        },
+      },
+    });
+
+    expect(registry.has('explore')).toBe(false);
+    expect(registry.size).toBe(2); // build + plan only
+  });
+
+  it('disabled agent in project file suppresses built-in', async () => {
+    const dir = path.join(TEST_DIR, 'disabled-file');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'explore.md'),
+      `---
+description: Disabled explore
+mode: subagent
+disabled: true
+---
+
+Disabled.`,
+    );
+
+    const { registry } = await buildAgentRegistry({
+      globalDir: path.join(TEST_DIR, 'nonexistent'),
+      projectDir: dir,
+    });
+
+    expect(registry.has('explore')).toBe(false);
+    expect(registry.size).toBe(2);
+  });
+
+  it('warns on invalid config agent name', async () => {
+    const { registry, warnings } = await buildAgentRegistry({
+      globalDir: path.join(TEST_DIR, 'nonexistent'),
+      projectDir: path.join(TEST_DIR, 'nonexistent'),
+      configAgents: {
+        'INVALID-NAME': {
+          description: 'Bad name',
+          mode: 'subagent',
+          disabled: false,
+        },
+      },
+    });
+
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]?.message).toContain('INVALID-NAME');
+    expect(registry.has('INVALID-NAME')).toBe(false);
+  });
+
+  it('full pipeline: built-in + global + project + config', async () => {
+    const globalDir = path.join(TEST_DIR, 'full-global');
+    const projectDir = path.join(TEST_DIR, 'full-project');
+    fs.mkdirSync(globalDir, { recursive: true });
+    fs.mkdirSync(projectDir, { recursive: true });
+
+    // Global: adds a linter agent
+    fs.writeFileSync(
+      path.join(globalDir, 'linter.md'),
+      `---
+description: Global linter
+mode: subagent
+---
+
+Lint code.`,
+    );
+
+    // Project: adds a reviewer, overrides explore
+    fs.writeFileSync(
+      path.join(projectDir, 'reviewer.md'),
+      `---
+description: Project reviewer
+mode: subagent
+---
+
+Review code.`,
+    );
+    fs.writeFileSync(
+      path.join(projectDir, 'explore.md'),
+      `---
+description: Project explore
+mode: subagent
+---
+
+Custom explore.`,
+    );
+
+    // Config: overrides linter, adds deployer
+    const { registry, warnings } = await buildAgentRegistry({
+      globalDir,
+      projectDir,
+      configAgents: {
+        linter: {
+          description: 'Config linter',
+          mode: 'subagent',
+          disabled: false,
+        },
+        deployer: {
+          description: 'Deploy specialist',
+          mode: 'subagent',
+          disabled: false,
+        },
+      },
+    });
+
+    expect(warnings).toEqual([]);
+    // build, plan, explore(project), linter(config), reviewer(project), deployer(config)
+    expect(registry.size).toBe(6);
+
+    expect(registry.get('build')?.source.type).toBe('builtin');
+    expect(registry.get('plan')?.source.type).toBe('builtin');
+    expect(registry.get('explore')?.source.type).toBe('project');
+    expect(registry.get('explore')?.description).toBe('Project explore');
+    expect(registry.get('linter')?.source.type).toBe('config');
+    expect(registry.get('linter')?.description).toBe('Config linter');
+    expect(registry.get('reviewer')?.source.type).toBe('project');
+    expect(registry.get('deployer')?.source.type).toBe('config');
+  });
+});


### PR DESCRIPTION
## Story 3: Agent Registry + Built-in Agents

Implements the central agent registry with built-in agent definitions for build, plan, and explore. Part of the user-defined agents epic (#28).

### Changes

**New files:**
- `src/agent/agents/builtins.ts` — Built-in agent definitions (build, plan, explore) with permission configs matching current mode behavior
- `src/agent/agents/registry.ts` — Immutable `AgentRegistry` class: `get()`, `list()`, `has()`, `listForTask()`
- `src/agent/agents/index.ts` — Public API barrel + `buildAgentRegistry()` merging pipeline
- `tests/test-agent-registry.ts` — 32 unit + integration tests

**Modified files:**
- `src/config/resolve.ts` — Added `extractAgentRegistry()` for config resolution integration
- `src/config/index.ts` — Re-export of `extractAgentRegistry`

### Merging Pipeline

```
built-in → global files → project files → JSON config
```

Later layers override earlier for the same agent name. Disabled agents are filtered at the end, so a project file with `disabled: true` correctly suppresses a built-in.

### Built-in Agents

| Name | Mode | Permissions |
|---|---|---|
| build | primary | `*: allow` |
| plan | primary | `edit: deny` |
| explore | subagent | `*: deny`, read/glob/grep/list/bash/web_fetch/todo: allow |

### Test Coverage (32 tests)

- Built-in agent properties (3)
- Registry CRUD: constructor, get, has (5)
- Mode filtering: primary, subagent, all (4)
- Permission-based task listing: glob patterns, deny-all, ask, mode:all (8)
- Integration: full pipeline, precedence, disabled, config override, warnings (12)

### Code Reviews
- **@code-reviewer**: No critical issues. Added clarifying comment on permission evaluation in listForTask.
- **@architect-reviewer**: No critical issues. Immutable registry design validated. Empty systemPrompt convention noted for Story 4 resolution.

Closes #106