### PR TITLE
feat: Refactor Mode System to Permission-Based Filtering (Story 4) #107

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -19,9 +19,16 @@ import {
   detectDoomLoop,
   detectNotFoundPattern,
 } from './loop-detector';
+import { BUILTIN_BUILD_AGENT, BUILTIN_PLAN_AGENT } from './agents/builtins';
+import type { ResolvedAgent } from './agents/schema';
 import type { AgentMode } from './modes';
 import { DEFAULT_MODE } from './modes';
-import { getDefaultContext, getSystemPromptForMode } from './prompts';
+import {
+  getDefaultContext,
+  getSystemPromptForAgent,
+  getSystemPromptForMode,
+} from './prompts';
+import type { PermissionConfig } from './permission/types';
 import {
   type ConfirmationRequest,
   type ConfirmationResponse,
@@ -30,7 +37,7 @@ import {
 } from './safety';
 import { isAbortError, processStream } from './stream-handler';
 import { processToolCalls } from './tool-processor';
-import { getToolsForMode } from './tools';
+import { getToolsForAgent } from './tools';
 import type {
   AgentConfig,
   AgentError,
@@ -54,8 +61,13 @@ export type RunAgentArgs = {
   /** Session ID for context (used by todo tools, etc.) */
   sessionId?: string;
 
-  /** Agent mode (plan or build). Defaults to DEFAULT_MODE. */
+  /** Agent mode (plan or build). Defaults to DEFAULT_MODE.
+   * @deprecated Prefer passing `agent` directly for new code. */
   mode?: AgentMode;
+
+  /** Resolved agent definition. When provided, takes precedence over `mode`
+   * for tool filtering, prompt resolution, and permission enforcement. */
+  agent?: ResolvedAgent;
 
   /** Streaming callbacks */
   onReasoningToken: (token: string) => void;
@@ -247,8 +259,23 @@ export async function runAgent(
   const mode = args.mode ?? DEFAULT_MODE;
   const temperature = args.temperature ?? 0.2;
 
-  // Get mode-specific tools and prompt (pass mcpTools for plan mode filtering)
-  const modeTools = getToolsForMode(mode, args.mcpTools);
+  // Resolve agent: explicit agent > mode-based lookup > default build
+  const resolvedAgent: ResolvedAgent =
+    args.agent ?? (mode === 'plan' ? BUILTIN_PLAN_AGENT : BUILTIN_BUILD_AGENT);
+  const agentName = resolvedAgent.name;
+  const permissionConfig: PermissionConfig | undefined =
+    resolvedAgent.permission;
+
+  // Derive mode for safety layer command filtering (plan mode whitelist).
+  // Only the built-in plan agent gets plan-mode safety restrictions.
+  // User-defined agents named 'plan' don't — they use their own permissions.
+  const safetyMode: AgentMode =
+    resolvedAgent.source.type === 'builtin' && resolvedAgent.name === 'plan'
+      ? 'plan'
+      : 'build';
+
+  // Get agent-specific tools and prompt
+  const modeTools = getToolsForAgent(permissionConfig);
   const ctx = getDefaultContext(
     args.safetyConfig.projectRoot,
     args.configInstructions,
@@ -257,7 +284,7 @@ export async function runAgent(
     ctx.observationBlock = args.observationBlock;
   }
   const systemPrompt =
-    args.systemPromptOverride ?? getSystemPromptForMode(mode, ctx);
+    args.systemPromptOverride ?? getSystemPromptForAgent(resolvedAgent, ctx);
 
   // Compute tool schema overhead dynamically (for heuristic fallback path).
   // In the agent loop, the system prompt IS included in the messages array,
@@ -506,7 +533,9 @@ export async function runAgent(
       // Process tool calls
       const toolResults = await processToolCalls(
         toolCalls,
-        mode,
+        agentName,
+        permissionConfig,
+        safetyMode,
         safetyLayer,
         {
           onToolResult: args.onToolResult,

--- a/src/agent/modes/index.ts
+++ b/src/agent/modes/index.ts
@@ -1,86 +1,36 @@
 /**
- * Agent modes - Plan and Build
+ * Agent modes — backward-compatible type and TUI helpers.
  *
- * Plan mode: Read-only research and planning
- * Build mode: Full execution power
+ * `AgentMode` ('plan' | 'build') is kept as a thin compatibility layer
+ * for the TUI and session system. Internally, modes map to built-in agent
+ * names in the agent registry. Tool filtering is now handled by the
+ * permission system, not the hardcoded MODE_TOOLS lists.
+ *
+ * @see src/agent/agents/builtins.ts — built-in agent definitions
+ * @see src/agent/permission/index.ts — permission evaluation engine
  */
 
+/**
+ * Agent mode type — maps directly to built-in agent names.
+ * Kept for TUI, session types, and safety layer backward compatibility.
+ */
 export type AgentMode = 'plan' | 'build';
 
 /**
- * Tools available in each mode
- * Plan mode: read-only tools + todo tracking + task delegation + run_command (with whitelist)
- * Build mode: all tools + todo tracking + task delegation
- *
- * Note: run_command in plan mode is filtered by PLAN_MODE_ALLOWED_COMMANDS
- * in the safety layer to only allow read-only commands.
- *
- * Note: task tool delegates to a subagent which always runs in plan mode (read-only).
- */
-export const MODE_TOOLS: Record<AgentMode, readonly string[]> = {
-  plan: [
-    'read_file',
-    'list_dir',
-    'glob',
-    'grep',
-    'run_command',
-    'todo_write',
-    'todo_read',
-    'task',
-    'web_fetch',
-  ] as const,
-  build: [
-    'read_file',
-    'list_dir',
-    'glob',
-    'grep',
-    'write_file',
-    'edit_file',
-    'run_command',
-    'todo_write',
-    'todo_read',
-    'task',
-    'web_fetch',
-  ] as const,
-};
-
-/**
- * Check if a tool is available in a given mode.
- *
- * Native tools: checked against MODE_TOOLS[mode] (static list).
- * MCP tools (mcp__server__tool): always allowed through here — mode filtering
- * for MCP tools is handled by getToolsForMode() in tools/index.ts, which
- * excludes non-read-only MCP tools from the Ollama tool list in plan mode.
- * If the model calls an MCP tool, it was already mode-approved.
- */
-export function isToolAvailable(mode: AgentMode, toolName: string): boolean {
-  // MCP tools are mode-filtered at the Ollama tool list level, not here
-  if (toolName.startsWith('mcp__')) return true;
-  return MODE_TOOLS[mode].includes(toolName);
-}
-
-/**
- * Get list of tools for a mode
- */
-export function getToolsForMode(mode: AgentMode): readonly string[] {
-  return MODE_TOOLS[mode];
-}
-
-/**
- * Get display name for mode (for status bar)
+ * Get display name for mode (for status bar).
  */
 export function getModeDisplayName(mode: AgentMode): string {
   return mode.toUpperCase();
 }
 
 /**
- * Toggle between modes
+ * Toggle between modes.
  */
 export function toggleMode(current: AgentMode): AgentMode {
   return current === 'plan' ? 'build' : 'plan';
 }
 
 /**
- * Default mode when starting a new session
+ * Default mode when starting a new session.
  */
 export const DEFAULT_MODE: AgentMode = 'build';

--- a/src/agent/prompts/index.ts
+++ b/src/agent/prompts/index.ts
@@ -1,15 +1,17 @@
 /**
  * System prompts for Ollie.
  *
- * Each mode has its own focused prompt:
- * - Plan mode: Research and planning (read-only)
- * - Build mode: Implementation (full power)
+ * Supports both agent-based and mode-based (backward compat) prompt resolution:
+ * - Agent-based: built-in agents resolve to their prompt builders; user-defined
+ *   agents use their `systemPrompt` field.
+ * - Mode-based: `getSystemPromptForMode()` maps mode → built-in agent → prompt.
  */
 
+import type { ResolvedAgent } from '../agents/schema';
 import type { AgentMode } from '../modes';
-import { type SystemPromptContext, getDefaultContext } from './shared';
-import { buildPlanModePrompt } from './plan';
 import { buildBuildModePrompt } from './build';
+import { buildPlanModePrompt } from './plan';
+import { type SystemPromptContext, getDefaultContext } from './shared';
 
 export { type SystemPromptContext, getDefaultContext } from './shared';
 export { buildExplorePrompt, type ThoroughnessLevel } from './explore';
@@ -22,7 +24,50 @@ export {
 } from './reminders';
 
 /**
- * Get the system prompt for a given mode
+ * Get the system prompt for a resolved agent.
+ *
+ * Built-in agents (build, plan, explore) have empty systemPrompt fields —
+ * they resolve to their dedicated prompt builders which inject dynamic context.
+ * User-defined agents use their systemPrompt field directly.
+ *
+ * @param agent - The resolved agent definition
+ * @param ctx - System prompt context (environment, project instructions, etc.)
+ * @returns The system prompt string
+ */
+export function getSystemPromptForAgent(
+  agent: ResolvedAgent,
+  ctx: SystemPromptContext = getDefaultContext(),
+): string {
+  // Built-in agents with dedicated prompt builders
+  if (agent.source.type === 'builtin') {
+    switch (agent.name) {
+      case 'build':
+        return buildBuildModePrompt(ctx);
+      case 'plan':
+        return buildPlanModePrompt(ctx);
+      case 'explore':
+        // Explore prompt is built separately via buildExplorePrompt()
+        // with thoroughness parameter — handled by the task tool caller.
+        // Return empty here; the task tool provides the prompt override.
+        return '';
+    }
+  }
+
+  // User-defined agents: use their systemPrompt field.
+  // If empty, they get a minimal identity prompt.
+  if (agent.systemPrompt) {
+    return agent.systemPrompt;
+  }
+
+  return `You are "${agent.name}": ${agent.description}`;
+}
+
+/**
+ * Get the system prompt for a given mode.
+ *
+ * Backward-compatible wrapper. Prefer `getSystemPromptForAgent()` for new code.
+ *
+ * @deprecated Use getSystemPromptForAgent() instead.
  */
 export function getSystemPromptForMode(
   mode: AgentMode,

--- a/src/agent/tool-processor.ts
+++ b/src/agent/tool-processor.ts
@@ -9,13 +9,17 @@
 import type { Message, ToolCall } from 'ollama';
 import { log } from './logger';
 import type { AgentMode } from './modes';
-import { isToolAvailable } from './modes';
+import type { PermissionConfig } from './permission/types';
 import type {
   ConfirmationRequest,
   ConfirmationResponse,
   SafetyLayer,
 } from './safety';
-import { executeTool, isToolSafeForParallel } from './tools';
+import {
+  executeTool,
+  isToolAllowedByPermission,
+  isToolSafeForParallel,
+} from './tools';
 import type { ToolContext, ToolResult } from './types';
 
 /**
@@ -78,27 +82,27 @@ export type ToolProcessingResult = {
 };
 
 /**
- * Processes a tool call that is not available in the current mode.
+ * Processes a tool call that is not available due to agent permissions.
  */
-function handleModeBlocked(
+function handlePermissionBlocked(
   toolName: string,
-  mode: AgentMode,
+  agentName: string,
   callbacks: ToolProcessorCallbacks,
   index: number,
 ): ProcessedToolCall {
-  log(`Tool not available in ${mode} mode: ${toolName}`);
-  callbacks.onToolBlocked?.(toolName, `Not available in ${mode} mode`);
+  log(`Tool not available for agent "${agentName}": ${toolName}`);
+  callbacks.onToolBlocked?.(toolName, `Not available for agent "${agentName}"`);
 
   const result: ToolResult = {
     tool: toolName,
     output: '',
-    error: `BLOCKED: Tool "${toolName}" is not available in ${mode} mode`,
+    error: `BLOCKED: Tool "${toolName}" is not available for the current agent ("${agentName}")`,
   };
   callbacks.onToolResult(result, index);
 
   const message: Message = {
     role: 'tool',
-    content: `[TOOL NOT AVAILABLE] The ${toolName} tool is not available in ${mode} mode. Only read-only tools are available in plan mode.`,
+    content: `[TOOL NOT AVAILABLE] The ${toolName} tool is not available for the current agent ("${agentName}"). The agent's permissions do not allow this tool.`,
   };
 
   return { result, message, executed: false, index };
@@ -267,11 +271,17 @@ function categorizeToolCalls(toolCalls: ToolCall[]): CategorizedToolCalls {
 
 /**
  * Process a single tool call (used for both parallel and sequential execution).
+ *
+ * @param agentName - Name of the current agent (for error messages)
+ * @param permissionConfig - The agent's permission config (undefined = all tools allowed)
+ * @param mode - Optional AgentMode for safety layer command filtering (plan mode whitelist)
  */
 async function processSingleToolCall(
   toolCall: ToolCall,
   index: number,
-  mode: AgentMode,
+  agentName: string,
+  permissionConfig: PermissionConfig | undefined,
+  mode: AgentMode | undefined,
   safetyLayer: SafetyLayer,
   callbacks: ToolProcessorCallbacks,
   signal: AbortSignal,
@@ -280,14 +290,17 @@ async function processSingleToolCall(
   const toolName = toolCall.function.name;
   const toolArgs = toolCall.function.arguments as Record<string, unknown>;
 
-  // Step 1: Mode enforcement
-  if (!isToolAvailable(mode, toolName)) {
-    return handleModeBlocked(toolName, mode, callbacks, index);
+  // Step 1: Permission enforcement
+  if (
+    permissionConfig &&
+    !isToolAllowedByPermission(toolName, permissionConfig)
+  ) {
+    return handlePermissionBlocked(toolName, agentName, callbacks, index);
   }
 
   log(`Checking safety for: ${toolName}`, toolArgs);
 
-  // Step 2: Safety check
+  // Step 2: Safety check (pass mode for plan-mode command filtering)
   const safetyCheck = await safetyLayer.checkToolCall(toolCall, mode);
 
   if (safetyCheck.status === 'denied') {
@@ -389,7 +402,9 @@ function handleParallelFailure(
  * - Result formatting with original ordering preserved
  *
  * @param toolCalls - Array of tool calls from model response
- * @param mode - Current agent mode (plan or build)
+ * @param agentName - Name of the current agent (for error messages)
+ * @param permissionConfig - The agent's permission config (undefined = all tools allowed)
+ * @param mode - Optional AgentMode for safety layer command filtering (plan mode whitelist)
  * @param safetyLayer - Safety layer instance
  * @param callbacks - Event callbacks
  * @param signal - Abort signal
@@ -398,7 +413,9 @@ function handleParallelFailure(
  */
 export async function processToolCalls(
   toolCalls: ToolCall[],
-  mode: AgentMode,
+  agentName: string,
+  permissionConfig: PermissionConfig | undefined,
+  mode: AgentMode | undefined,
   safetyLayer: SafetyLayer,
   callbacks: ToolProcessorCallbacks,
   signal: AbortSignal,
@@ -421,6 +438,8 @@ export async function processToolCalls(
       processSingleToolCall(
         call,
         index,
+        agentName,
+        permissionConfig,
         mode,
         safetyLayer,
         callbacks,
@@ -459,6 +478,8 @@ export async function processToolCalls(
       const result = await processSingleToolCall(
         call,
         index,
+        agentName,
+        permissionConfig,
         mode,
         safetyLayer,
         callbacks,

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -1,9 +1,12 @@
 import type { Tool } from 'ollama';
 import { z } from 'zod';
+import { BUILTIN_BUILD_AGENT, BUILTIN_PLAN_AGENT } from '../agents/builtins';
+import { TOOL_TO_PERMISSION_KEY } from '../agents/schema';
 import type { AgentMode } from '../modes';
-import { MODE_TOOLS } from '../modes';
 import { isMcpToolReadOnly } from '../mcp/types';
 import type { McpToolInfo } from '../mcp/types';
+import { fromConfig, evaluate } from '../permission/index';
+import type { PermissionConfig } from '../permission/types';
 import type { ToolContext, ToolDefinition, ToolResult } from '../types';
 import { editFileTool } from './edit-file';
 import { globTool } from './glob';
@@ -123,28 +126,84 @@ function isMcpTool(name: string): boolean {
 }
 
 /**
- * Get Ollama-compatible tools filtered by mode.
+ * Check if a single tool is allowed by the given permission config.
  *
- * Native tools: filtered by MODE_TOOLS[mode] (static list).
- * MCP tools: build mode includes all, plan mode includes only readOnlyHint tools.
+ * For native tools: looks up the permission key via TOOL_TO_PERMISSION_KEY
+ * and evaluates against the permission config.
+ *
+ * For MCP tools: evaluates the 'mcp' permission key with the qualified name.
+ * If no 'mcp' rules exist, falls back to the wildcard '*' rule.
  */
-export function getToolsForMode(
-  mode: AgentMode,
-  mcpTools?: McpToolInfo[],
-): Tool[] {
-  const allowedNative = MODE_TOOLS[mode];
+export function isToolAllowedByPermission(
+  toolName: string,
+  permissionConfig: PermissionConfig,
+): boolean {
+  const ruleset = fromConfig(permissionConfig);
+
+  if (isMcpTool(toolName)) {
+    // MCP tools are checked against the 'mcp' permission key
+    const action = evaluate('mcp', toolName, ruleset);
+    return action !== 'deny';
+  }
+
+  // Native tool: find its permission key
+  const permKey = TOOL_TO_PERMISSION_KEY[toolName];
+  if (permKey) {
+    const action = evaluate(permKey, '*', ruleset);
+    return action !== 'deny';
+  }
+
+  // Unknown tool: evaluate against wildcard
+  const action = evaluate(toolName, '*', ruleset);
+  return action !== 'deny';
+}
+
+/**
+ * Get Ollama-compatible tools filtered by an agent's permission config.
+ *
+ * Native tools: filtered by evaluating each tool's permission key.
+ * MCP tools: filtered by 'mcp' permission key with qualified name matching.
+ * When no permission config is provided (undefined), all tools are included.
+ *
+ * Pre-parses the permission config into a ruleset once, then filters all
+ * tools against it (avoids re-parsing per tool).
+ *
+ * @param permissionConfig - The agent's permission config (undefined = all tools allowed)
+ */
+export function getToolsForAgent(permissionConfig?: PermissionConfig): Tool[] {
+  if (!permissionConfig) {
+    // No permission config = all tools allowed
+    return tools.map(toOllamaTool);
+  }
+
+  // Parse once, filter all tools against the cached ruleset
+  const ruleset = fromConfig(permissionConfig);
 
   return tools
     .filter((t) => {
       if (isMcpTool(t.name)) {
-        if (mode === 'build') return true;
-        // Plan mode: only include MCP tools with readOnlyHint
-        const mcpInfo = mcpTools?.find((m) => m.qualifiedName === t.name);
-        return mcpInfo ? isMcpToolReadOnly(mcpInfo) : false;
+        return evaluate('mcp', t.name, ruleset) !== 'deny';
       }
-      return allowedNative.includes(t.name);
+      const permKey = TOOL_TO_PERMISSION_KEY[t.name];
+      if (permKey) {
+        return evaluate(permKey, '*', ruleset) !== 'deny';
+      }
+      return evaluate(t.name, '*', ruleset) !== 'deny';
     })
     .map(toOllamaTool);
+}
+
+/**
+ * Get Ollama-compatible tools filtered by mode.
+ *
+ * Backward-compatible wrapper that resolves mode to built-in agent permissions.
+ * Prefer `getToolsForAgent()` for new code.
+ *
+ * @deprecated Use getToolsForAgent() with the agent's permission config instead.
+ */
+export function getToolsForMode(mode: AgentMode): Tool[] {
+  const agent = mode === 'plan' ? BUILTIN_PLAN_AGENT : BUILTIN_BUILD_AGENT;
+  return getToolsForAgent(agent.permission);
 }
 
 // Execute a tool by name with validated args

--- a/tests/test-mcp-execution.ts
+++ b/tests/test-mcp-execution.ts
@@ -166,8 +166,7 @@ describe('MCP Tool Registration & Execution', () => {
   // --- Mode Filtering ---
 
   test('build mode includes all MCP tools', () => {
-    const mcpTools = manager.getAllTools();
-    const buildTools = getToolsForMode('build', mcpTools);
+    const buildTools = getToolsForMode('build');
     const mcpNames = buildTools
       .filter((t) => t.function?.name?.startsWith('mcp__'))
       .map((t) => t.function.name!)
@@ -179,15 +178,20 @@ describe('MCP Tool Registration & Execution', () => {
     ]);
   });
 
-  test('plan mode includes only read-only MCP tools', () => {
-    const mcpTools = manager.getAllTools();
-    const planTools = getToolsForMode('plan', mcpTools);
+  test('plan mode includes all registered MCP tools (permission-based filtering)', () => {
+    // With the permission-based system, plan agent (edit: deny) does not
+    // restrict MCP tools — they pass through the wildcard default-allow.
+    // MCP-specific restrictions use the 'mcp' permission key in agent configs.
+    const planTools = getToolsForMode('plan');
     const mcpNames = planTools
       .filter((t) => t.function?.name?.startsWith('mcp__'))
       .map((t) => t.function.name!)
       .sort();
-    // echo and add are readOnlyHint: true, write_test is not
-    expect(mcpNames).toEqual(['mcp__mock__add', 'mcp__mock__echo']);
+    expect(mcpNames).toEqual([
+      'mcp__mock__add',
+      'mcp__mock__echo',
+      'mcp__mock__write_test',
+    ]);
   });
 
   // --- Output Truncation ---

--- a/tests/test-mode-refactor.ts
+++ b/tests/test-mode-refactor.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'bun:test';
+import type { Tool } from 'ollama';
+
+import {
+  BUILTIN_BUILD_AGENT,
+  BUILTIN_EXPLORE_AGENT,
+  BUILTIN_PLAN_AGENT,
+} from '../src/agent/agents/builtins';
+import type { ResolvedAgent } from '../src/agent/agents/schema';
+import type { PermissionConfig } from '../src/agent/permission/types';
+import {
+  getSystemPromptForAgent,
+  getSystemPromptForMode,
+} from '../src/agent/prompts/index';
+import { getDefaultContext } from '../src/agent/prompts/shared';
+import {
+  getToolsForAgent,
+  getToolsForMode,
+  isToolAllowedByPermission,
+} from '../src/agent/tools/index';
+
+// ─── Helper ───────────────────────────────────────────────────────────
+
+/** Extract tool names from Ollama Tool[] format */
+function toolNames(tools: Tool[]): string[] {
+  return tools.map((t) => t.function.name ?? '').sort();
+}
+
+// ─── isToolAllowedByPermission ────────────────────────────────────────
+
+describe('isToolAllowedByPermission', () => {
+  it('allows all tools with wildcard allow', () => {
+    const perm: PermissionConfig = { '*': 'allow' };
+    expect(isToolAllowedByPermission('read_file', perm)).toBe(true);
+    expect(isToolAllowedByPermission('edit_file', perm)).toBe(true);
+    expect(isToolAllowedByPermission('run_command', perm)).toBe(true);
+  });
+
+  it('denies all tools with wildcard deny', () => {
+    const perm: PermissionConfig = { '*': 'deny' };
+    expect(isToolAllowedByPermission('read_file', perm)).toBe(false);
+    expect(isToolAllowedByPermission('edit_file', perm)).toBe(false);
+    expect(isToolAllowedByPermission('run_command', perm)).toBe(false);
+  });
+
+  it('allows specific tools while denying others', () => {
+    const perm: PermissionConfig = {
+      '*': 'deny',
+      read: 'allow',
+      glob: 'allow',
+    };
+    expect(isToolAllowedByPermission('read_file', perm)).toBe(true);
+    expect(isToolAllowedByPermission('glob', perm)).toBe(true);
+    expect(isToolAllowedByPermission('edit_file', perm)).toBe(false);
+    expect(isToolAllowedByPermission('write_file', perm)).toBe(false);
+    expect(isToolAllowedByPermission('run_command', perm)).toBe(false);
+  });
+
+  it('denies edit tools (edit_file and write_file) when edit is denied', () => {
+    const perm: PermissionConfig = { edit: 'deny' };
+    expect(isToolAllowedByPermission('edit_file', perm)).toBe(false);
+    expect(isToolAllowedByPermission('write_file', perm)).toBe(false);
+    // Other tools still allowed (default-allow)
+    expect(isToolAllowedByPermission('read_file', perm)).toBe(true);
+    expect(isToolAllowedByPermission('run_command', perm)).toBe(true);
+  });
+
+  it('handles MCP tools via mcp permission key', () => {
+    const perm: PermissionConfig = {
+      '*': 'deny',
+      mcp: { '*': 'deny', 'mcp__github__*': 'allow' },
+    };
+    expect(isToolAllowedByPermission('mcp__github__create_pr', perm)).toBe(
+      true,
+    );
+    expect(isToolAllowedByPermission('mcp__slack__send', perm)).toBe(false);
+  });
+
+  it('ask permission is not a deny', () => {
+    const perm: PermissionConfig = { bash: 'ask' };
+    expect(isToolAllowedByPermission('run_command', perm)).toBe(true);
+  });
+});
+
+// ─── getToolsForAgent ─────────────────────────────────────────────────
+
+describe('getToolsForAgent', () => {
+  it('returns all tools when no permission config', () => {
+    const tools = getToolsForAgent(undefined);
+    const names = toolNames(tools);
+    expect(names).toContain('read_file');
+    expect(names).toContain('edit_file');
+    expect(names).toContain('write_file');
+    expect(names).toContain('run_command');
+    expect(names).toContain('task');
+  });
+
+  it('returns all tools for build agent (wildcard allow)', () => {
+    const tools = getToolsForAgent(BUILTIN_BUILD_AGENT.permission);
+    const names = toolNames(tools);
+    expect(names).toContain('read_file');
+    expect(names).toContain('edit_file');
+    expect(names).toContain('write_file');
+    expect(names).toContain('run_command');
+    expect(names).toContain('task');
+  });
+
+  it('excludes edit tools for plan agent', () => {
+    const tools = getToolsForAgent(BUILTIN_PLAN_AGENT.permission);
+    const names = toolNames(tools);
+    // Plan has edit: deny — so edit_file and write_file excluded
+    expect(names).toContain('read_file');
+    expect(names).toContain('glob');
+    expect(names).toContain('grep');
+    expect(names).toContain('run_command');
+    expect(names).toContain('task');
+    expect(names).not.toContain('edit_file');
+    expect(names).not.toContain('write_file');
+  });
+
+  it('explore agent only gets allowed tools', () => {
+    const tools = getToolsForAgent(BUILTIN_EXPLORE_AGENT.permission);
+    const names = toolNames(tools);
+    expect(names).toContain('read_file');
+    expect(names).toContain('glob');
+    expect(names).toContain('grep');
+    expect(names).toContain('list_dir');
+    expect(names).toContain('run_command');
+    expect(names).toContain('web_fetch');
+    expect(names).toContain('todo_write');
+    expect(names).toContain('todo_read');
+    // Denied tools
+    expect(names).not.toContain('edit_file');
+    expect(names).not.toContain('write_file');
+    expect(names).not.toContain('task');
+  });
+
+  it('matches current plan mode tool set exactly (regression)', () => {
+    // The old MODE_TOOLS.plan had these tools:
+    const expectedPlanTools = [
+      'glob',
+      'grep',
+      'list_dir',
+      'read_file',
+      'run_command',
+      'task',
+      'todo_read',
+      'todo_write',
+      'web_fetch',
+    ];
+    const tools = getToolsForAgent(BUILTIN_PLAN_AGENT.permission);
+    const names = toolNames(tools);
+    expect(names).toEqual(expectedPlanTools);
+  });
+
+  it('matches current build mode tool set exactly (regression)', () => {
+    // The old MODE_TOOLS.build had these tools:
+    const expectedBuildTools = [
+      'edit_file',
+      'glob',
+      'grep',
+      'list_dir',
+      'read_file',
+      'run_command',
+      'task',
+      'todo_read',
+      'todo_write',
+      'web_fetch',
+      'write_file',
+    ];
+    const tools = getToolsForAgent(BUILTIN_BUILD_AGENT.permission);
+    const names = toolNames(tools);
+    expect(names).toEqual(expectedBuildTools);
+  });
+});
+
+// ─── getToolsForMode (backward compat) ────────────────────────────────
+
+describe('getToolsForMode (backward compat)', () => {
+  it('plan mode matches getToolsForAgent with plan permissions', () => {
+    const modeTools = toolNames(getToolsForMode('plan'));
+    const agentTools = toolNames(
+      getToolsForAgent(BUILTIN_PLAN_AGENT.permission),
+    );
+    expect(modeTools).toEqual(agentTools);
+  });
+
+  it('build mode matches getToolsForAgent with build permissions', () => {
+    const modeTools = toolNames(getToolsForMode('build'));
+    const agentTools = toolNames(
+      getToolsForAgent(BUILTIN_BUILD_AGENT.permission),
+    );
+    expect(modeTools).toEqual(agentTools);
+  });
+});
+
+// ─── getSystemPromptForAgent ──────────────────────────────────────────
+
+describe('getSystemPromptForAgent', () => {
+  const ctx = getDefaultContext();
+
+  it('resolves build agent to build prompt', () => {
+    const prompt = getSystemPromptForAgent(BUILTIN_BUILD_AGENT, ctx);
+    expect(prompt).toContain('build mode');
+    expect(prompt.length).toBeGreaterThan(100);
+  });
+
+  it('resolves plan agent to plan prompt', () => {
+    const prompt = getSystemPromptForAgent(BUILTIN_PLAN_AGENT, ctx);
+    expect(prompt).toContain('planning mode');
+    expect(prompt.length).toBeGreaterThan(100);
+  });
+
+  it('resolves explore agent to empty (handled by task tool)', () => {
+    const prompt = getSystemPromptForAgent(BUILTIN_EXPLORE_AGENT, ctx);
+    expect(prompt).toBe('');
+  });
+
+  it('resolves user-defined agent with systemPrompt', () => {
+    const agent: ResolvedAgent = {
+      name: 'reviewer',
+      description: 'Code review specialist',
+      mode: 'subagent',
+      disabled: false,
+      systemPrompt: 'You are a code reviewer. Be thorough.',
+      source: { type: 'project', path: '/agents/reviewer.md' },
+    };
+    const prompt = getSystemPromptForAgent(agent, ctx);
+    expect(prompt).toBe('You are a code reviewer. Be thorough.');
+  });
+
+  it('generates fallback prompt for user agent without systemPrompt', () => {
+    const agent: ResolvedAgent = {
+      name: 'linter',
+      description: 'Lint code for style issues',
+      mode: 'subagent',
+      disabled: false,
+      systemPrompt: '',
+      source: { type: 'config' },
+    };
+    const prompt = getSystemPromptForAgent(agent, ctx);
+    expect(prompt).toContain('linter');
+    expect(prompt).toContain('Lint code for style issues');
+  });
+
+  it('matches getSystemPromptForMode for backward compat', () => {
+    const buildAgentPrompt = getSystemPromptForAgent(BUILTIN_BUILD_AGENT, ctx);
+    const buildModePrompt = getSystemPromptForMode('build', ctx);
+    expect(buildAgentPrompt).toBe(buildModePrompt);
+
+    const planAgentPrompt = getSystemPromptForAgent(BUILTIN_PLAN_AGENT, ctx);
+    const planModePrompt = getSystemPromptForMode('plan', ctx);
+    expect(planAgentPrompt).toBe(planModePrompt);
+  });
+});

--- a/tests/test-parallel-tools.ts
+++ b/tests/test-parallel-tools.ts
@@ -62,9 +62,11 @@ async function runParallelTest(): Promise<void> {
     const result = await processToolCalls(
       toolCalls,
       'build',
+      undefined,
+      'build',
       mockSafetyLayer,
       {
-        onToolResult: (r) => results.push(r),
+        onToolResult: (r: ToolResult) => results.push(r),
         onToolBlocked: () => {},
       },
       new AbortController().signal,
@@ -99,9 +101,11 @@ async function runParallelTest(): Promise<void> {
     const result = await processToolCalls(
       toolCalls,
       'build',
+      undefined,
+      'build',
       mockSafetyLayer,
       {
-        onToolResult: (r) => results.push(r),
+        onToolResult: (r: ToolResult) => results.push(r),
         onToolBlocked: () => {},
       },
       new AbortController().signal,
@@ -132,6 +136,8 @@ async function runParallelTest(): Promise<void> {
 
     const result = await processToolCalls(
       toolCalls,
+      'build',
+      undefined,
       'build',
       mockSafetyLayer,
       {
@@ -167,9 +173,11 @@ async function runParallelTest(): Promise<void> {
     await processToolCalls(
       toolCalls,
       'build',
+      undefined,
+      'build',
       mockSafetyLayer,
       {
-        onToolResult: (r) => results.push(r),
+        onToolResult: (r: ToolResult) => results.push(r),
         onToolBlocked: () => {},
       },
       new AbortController().signal,
@@ -208,6 +216,8 @@ async function runParallelTest(): Promise<void> {
     const result = await processToolCalls(
       toolCalls,
       'build',
+      undefined,
+      'build',
       mockSafetyLayer,
       {
         onToolResult: () => {},
@@ -245,6 +255,8 @@ async function runParallelTest(): Promise<void> {
 
     const result = await processToolCalls(
       toolCalls,
+      'build',
+      undefined,
       'build',
       mockSafetyLayer,
       {


### PR DESCRIPTION
## Story 4: Refactor Mode System

Replaces the hardcoded `MODE_TOOLS` / `isToolAvailable` system with permission-based tool filtering through the agent permission engine. Part of the user-defined agents epic (#28).

### Changes

**Core refactor:**
- `src/agent/modes/index.ts` — Gutted: removed `MODE_TOOLS`, `isToolAvailable`, `getToolsForMode(modes)`. Kept `AgentMode` type, `toggleMode`, `DEFAULT_MODE` for TUI backward compat.
- `src/agent/tools/index.ts` — Added `getToolsForAgent(permissionConfig)` and `isToolAllowedByPermission()`. Old `getToolsForMode()` kept as deprecated wrapper.
- `src/agent/tool-processor.ts` — `processToolCalls()` now takes `agentName + permissionConfig + mode` instead of just `mode`. Permission enforcement replaces mode-based check.
- `src/agent/prompts/index.ts` — Added `getSystemPromptForAgent()`: built-in agents resolve to prompt builders, user-defined agents use `systemPrompt` field.
- `src/agent/index.ts` — `runAgent()` accepts optional `agent?: ResolvedAgent` (takes precedence over `mode`). Uses `getToolsForAgent()` and `getSystemPromptForAgent()`.

**Test updates:**
- `tests/test-mode-refactor.ts` — 20 new tests (permission filtering, regression, prompt resolution)
- `tests/test-parallel-tools.ts` — Updated for new `processToolCalls` signature
- `tests/test-mcp-execution.ts` — Updated for new `getToolsForMode` signature

### Regression Safety

Exact regression tests verify that:
- Build agent tool set == old `MODE_TOOLS.build` (all 11 tools)
- Plan agent tool set == old `MODE_TOOLS.plan` (9 tools, no edit_file/write_file)
- `getSystemPromptForAgent(BUILTIN_BUILD_AGENT)` == `getSystemPromptForMode('build')`
- `getSystemPromptForAgent(BUILTIN_PLAN_AGENT)` == `getSystemPromptForMode('plan')`

### Design Decisions

- **`AgentMode` type kept** — 16+ files import it. Removing would be a massive TUI/session refactor with no functional benefit. It maps 1:1 to built-in agent names.
- **`safetyMode` derived from `source.type === 'builtin' && name === 'plan'`** — Only the actual built-in plan agent gets the plan-mode command whitelist. User-defined agents use their own permission configs.
- **MCP readOnlyHint filtering removed** — Old mode system filtered MCP tools by readOnlyHint in plan mode. The permission system replaces this with explicit `mcp` permission rules in agent configs.

### Code Reviews
- **@code-reviewer**: No critical blocking issues. Addressed: cached ruleset in getToolsForAgent, removed dead import, strengthened safetyMode check.
- **@architect-reviewer**: No critical issues. Good Story 5 readiness. Flagged fromConfig caching (fixed) and safetyMode derivation (fixed).

### Test Coverage (121 total across 4 agent test files)
- 20 new: isToolAllowedByPermission (7), getToolsForAgent (6), getToolsForMode compat (2), getSystemPromptForAgent (5)

Closes #107