### PR TITLE
feat(agents): Task Tool + Subagent Invocation (Story 5)

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -98,6 +98,12 @@ export type RunAgentArgs = {
   /** Override the system prompt (used by subagents) */
   systemPromptOverride?: string;
 
+  /** Agent registry for subagent delegation (passed to task tool context) */
+  agentRegistry?: import('./agents/registry').AgentRegistry;
+
+  /** Current delegation depth (0 = top-level). Task tool increments on nesting. */
+  delegationDepth?: number;
+
   /** MCP tool metadata for mode filtering (plan mode: readOnlyHint only) */
   mcpTools?: import('./mcp/types').McpToolInfo[];
 
@@ -274,8 +280,13 @@ export async function runAgent(
       ? 'plan'
       : 'build';
 
+  // Build list of available subagents for the task tool description (per-run, no mutation)
+  const availableSubagents = args.agentRegistry
+    ? args.agentRegistry.listForTask(permissionConfig)
+    : undefined;
+
   // Get agent-specific tools and prompt
-  const modeTools = getToolsForAgent(permissionConfig);
+  const modeTools = getToolsForAgent(permissionConfig, availableSubagents);
   const ctx = getDefaultContext(
     args.safetyConfig.projectRoot,
     args.configInstructions,
@@ -552,6 +563,10 @@ export async function runAgent(
             safetyConfig: args.safetyConfig,
             toolsConfig: args.toolsConfig,
             configInstructions: args.configInstructions,
+            agentRegistry: args.agentRegistry,
+            callerPermission: permissionConfig,
+            runSubagent: runAgent,
+            delegationDepth: args.delegationDepth ?? 0,
           },
         },
       );

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -3,8 +3,6 @@ import { z } from 'zod';
 import { BUILTIN_BUILD_AGENT, BUILTIN_PLAN_AGENT } from '../agents/builtins';
 import { TOOL_TO_PERMISSION_KEY } from '../agents/schema';
 import type { AgentMode } from '../modes';
-import { isMcpToolReadOnly } from '../mcp/types';
-import type { McpToolInfo } from '../mcp/types';
 import { fromConfig, evaluate } from '../permission/index';
 import type { PermissionConfig } from '../permission/types';
 import type { ToolContext, ToolDefinition, ToolResult } from '../types';
@@ -14,7 +12,7 @@ import { grepTool } from './grep';
 import { listDirTool } from './list-dir';
 import { readFileTool } from './read-file';
 import { runCommandTool } from './run-command';
-import { taskTool } from './task';
+import { taskTool, buildTaskToolDescription } from './task';
 import { todoReadTool, todoWriteTool } from './todo';
 import { webFetchTool } from './web-fetch';
 import { writeFileTool } from './write-file';
@@ -168,29 +166,43 @@ export function isToolAllowedByPermission(
  * Pre-parses the permission config into a ruleset once, then filters all
  * tools against it (avoids re-parsing per tool).
  *
+ * When `taskToolAgents` is provided, the task tool's description is overridden
+ * in the returned Tool[] (per-call clone, no shared state mutation).
+ *
  * @param permissionConfig - The agent's permission config (undefined = all tools allowed)
+ * @param taskToolAgents - Available subagents for the task tool description (optional)
  */
-export function getToolsForAgent(permissionConfig?: PermissionConfig): Tool[] {
-  if (!permissionConfig) {
-    // No permission config = all tools allowed
-    return tools.map(toOllamaTool);
-  }
-
+export function getToolsForAgent(
+  permissionConfig?: PermissionConfig,
+  taskToolAgents?: ReadonlyArray<{ name: string; description: string }>,
+): Tool[] {
   // Parse once, filter all tools against the cached ruleset
-  const ruleset = fromConfig(permissionConfig);
+  const filteredTools = permissionConfig
+    ? (() => {
+        const ruleset = fromConfig(permissionConfig);
+        return tools.filter((t) => {
+          if (isMcpTool(t.name)) {
+            return evaluate('mcp', t.name, ruleset) !== 'deny';
+          }
+          const permKey = TOOL_TO_PERMISSION_KEY[t.name];
+          if (permKey) {
+            return evaluate(permKey, '*', ruleset) !== 'deny';
+          }
+          return evaluate(t.name, '*', ruleset) !== 'deny';
+        });
+      })()
+    : tools;
 
-  return tools
-    .filter((t) => {
-      if (isMcpTool(t.name)) {
-        return evaluate('mcp', t.name, ruleset) !== 'deny';
-      }
-      const permKey = TOOL_TO_PERMISSION_KEY[t.name];
-      if (permKey) {
-        return evaluate(permKey, '*', ruleset) !== 'deny';
-      }
-      return evaluate(t.name, '*', ruleset) !== 'deny';
-    })
-    .map(toOllamaTool);
+  return filteredTools.map((t) => {
+    // Override task tool description with available agents (per-call, no mutation)
+    if (t.name === 'task' && taskToolAgents) {
+      return toOllamaTool({
+        ...t,
+        description: buildTaskToolDescription(taskToolAgents),
+      });
+    }
+    return toOllamaTool(t);
+  });
 }
 
 /**

--- a/src/agent/tools/task.ts
+++ b/src/agent/tools/task.ts
@@ -1,21 +1,34 @@
 /**
- * Task Tool - Delegates complex exploration tasks to a specialized subagent.
+ * Task Tool - Delegates tasks to named subagents via the agent registry.
  *
- * This enables the primary agent to offload complex, multi-step exploration
- * to a focused subagent with its own context window and iteration budget.
+ * The task tool resolves the target agent from the registry, verifies the
+ * calling agent has permission to invoke it, then runs the subagent with
+ * its configured tools, prompt, and iteration budget in an isolated context.
  */
 
 import { z } from 'zod';
-import { runAgent } from '../index';
-import { buildExplorePrompt, type ThoroughnessLevel } from '../prompts/explore';
-import { getDefaultContext } from '../prompts/shared';
+import { ITERATION_PRESETS } from '../agents/schema';
+import type { ResolvedAgent } from '../agents/schema';
+import { fromConfig, evaluate } from '../permission/index';
+import type { PermissionConfig } from '../permission/types';
+import { buildExplorePrompt } from '../prompts/explore';
+import { getDefaultContext, getSystemPromptForAgent } from '../prompts';
 import type { ToolDefinition } from '../types';
 
 // ============================================================================
 // Schema Definitions
 // ============================================================================
 
+const MaxIterationsInputSchema = z.union([
+  z.number().int().positive(),
+  z.enum(['quick', 'medium', 'thorough']),
+]);
+
 const taskInput = z.object({
+  agent: z
+    .string()
+    .min(1)
+    .describe('Name of the agent to delegate to (e.g. "explore", "reviewer")'),
   description: z
     .string()
     .min(1)
@@ -24,29 +37,139 @@ const taskInput = z.object({
     .string()
     .min(1)
     .describe('Detailed task description for the subagent'),
-  thoroughness: z
-    .enum(['quick', 'medium', 'thorough'])
-    .optional()
-    .default('medium')
-    .describe('How thorough the exploration should be'),
+  maxIterations: MaxIterationsInputSchema.optional().describe(
+    'Override iteration budget: number or preset (quick/medium/thorough)',
+  ),
 });
 
 const taskOutput = z.object({
   success: z.boolean(),
   output: z.string(),
+  agent: z.string(),
   filesExplored: z.array(z.string()),
   iterations: z.number(),
 });
 
 // ============================================================================
-// Iteration Limits by Thoroughness
+// Constants
 // ============================================================================
 
-const ITERATION_LIMITS: Record<ThoroughnessLevel, number> = {
-  quick: 8,
-  medium: 15,
-  thorough: 25,
-};
+/** Global cap for subagent iterations (safety net). */
+const MAX_SUBAGENT_ITERATIONS = 50;
+
+/** Maximum delegation depth to prevent unbounded recursion. */
+export const MAX_DELEGATION_DEPTH = 3;
+
+/** Default iteration budget when no override or agent config exists. */
+const DEFAULT_ITERATIONS = ITERATION_PRESETS.medium;
+
+// ============================================================================
+// Helpers (exported for testing)
+// ============================================================================
+
+/**
+ * Resolve the effective maxIterations for a subagent invocation.
+ *
+ * Priority: task call override -> agent config -> global default.
+ * Always capped by MAX_SUBAGENT_ITERATIONS.
+ */
+export function resolveMaxIterations(
+  callOverride: number | 'quick' | 'medium' | 'thorough' | undefined,
+  agentConfig: number | 'quick' | 'medium' | 'thorough' | undefined,
+): number {
+  const raw = callOverride ?? agentConfig;
+  let value: number;
+
+  if (raw === undefined) {
+    value = DEFAULT_ITERATIONS;
+  } else if (typeof raw === 'string') {
+    value = ITERATION_PRESETS[raw];
+  } else {
+    value = raw;
+  }
+
+  return Math.min(value, MAX_SUBAGENT_ITERATIONS);
+}
+
+/**
+ * Check if the calling agent is permitted to invoke a subagent.
+ *
+ * Evaluates the caller's `task` permission key with the target agent name.
+ * No caller permission config = default allow (can invoke any subagent).
+ */
+function isSubagentAllowed(
+  callerPermission: PermissionConfig | undefined,
+  targetAgentName: string,
+): boolean {
+  if (!callerPermission) return true;
+  const ruleset = fromConfig(callerPermission);
+  const action = evaluate('task', targetAgentName, ruleset);
+  return action !== 'deny';
+}
+
+/**
+ * Build the system prompt for the subagent invocation.
+ *
+ * Built-in explore agent gets its dedicated prompt builder with thoroughness.
+ * Other agents get their systemPrompt via getSystemPromptForAgent().
+ */
+function buildSubagentPrompt(
+  agent: ResolvedAgent,
+  maxIterations: number,
+  projectRoot?: string,
+  configInstructions?: string[],
+): string {
+  // Built-in explore agent uses its dedicated prompt builder
+  if (agent.source.type === 'builtin' && agent.name === 'explore') {
+    const ctx = getDefaultContext(projectRoot, configInstructions);
+    // Map iteration count to thoroughness level for explore prompt
+    const thoroughness =
+      maxIterations <= ITERATION_PRESETS.quick
+        ? 'quick'
+        : maxIterations >= ITERATION_PRESETS.thorough
+          ? 'thorough'
+          : 'medium';
+    return buildExplorePrompt(ctx, thoroughness);
+  }
+
+  // All other agents: use getSystemPromptForAgent()
+  const ctx = getDefaultContext(projectRoot, configInstructions);
+  return getSystemPromptForAgent(agent, ctx);
+}
+
+/**
+ * Build the dynamic task tool description listing available agents.
+ *
+ * Called when the registry is available to produce a description that shows
+ * the LLM which agents it can delegate to.
+ */
+export function buildTaskToolDescription(
+  availableAgents: ReadonlyArray<{ name: string; description: string }>,
+): string {
+  const agentList = availableAgents
+    .map((a) => `- ${a.name}: ${a.description}`)
+    .join('\n');
+
+  return `Delegate tasks to a specialized subagent. You MUST specify which agent to use.
+
+Available agents:
+${agentList}
+
+When to use:
+- Complex multi-step tasks that benefit from a focused specialist
+- Research or exploration requiring many iterations
+- Tasks that need a restricted tool set for safety
+
+PARALLEL EXECUTION: You can call multiple task tools in a single response!
+Launch parallel tasks for independent work:
+- task(agent="explore", prompt="find auth logic") AND task(agent="explore", prompt="find DB schema")
+
+Parameters:
+- agent (required): Name of the agent from the list above
+- prompt (required): Detailed task description for the subagent
+- description (required): Short 3-5 word label
+- maxIterations (optional): Override iteration budget (number or "quick"/"medium"/"thorough")`;
+}
 
 // ============================================================================
 // Task Tool Definition
@@ -54,84 +177,141 @@ const ITERATION_LIMITS: Record<ThoroughnessLevel, number> = {
 
 export const taskTool: ToolDefinition<typeof taskInput, typeof taskOutput> = {
   name: 'task',
-  description: `Delegate complex exploration or research tasks to a specialized subagent.
-
-The explore subagent is a fast file/code search specialist. Use it for:
-- Complex searches across multiple directories
-- Open-ended exploration ("what does this codebase do?")
-- Finding patterns across many files
-- Research that requires multiple search iterations
-
-When to use:
-- Questions requiring exploration of 5+ files
-- "How does X work?" questions about unfamiliar code
-- Finding all usages of a pattern across the codebase
-- Understanding project architecture
-
-When NOT to use:
-- Reading a specific known file (use read_file)
-- Simple grep for a single pattern (use grep)
-- Quick directory listing (use list_dir)
-- Questions you can answer from files already read
-
-Thoroughness levels:
-- quick: 2-3 files, surface overview (8 iterations max)
-- medium: 5-10 files, balanced exploration (15 iterations max)
-- thorough: comprehensive analysis (25 iterations max)
-
-PARALLEL EXECUTION: You can call multiple task tools in a single response!
-When exploring different areas of the codebase, launch tasks in parallel:
-- task(prompt="explore agent/") AND task(prompt="explore tui/") together
-- task(prompt="find error handling") AND task(prompt="find logging patterns")
-The tasks will run concurrently and you'll receive all results together.`,
+  description: buildTaskToolDescription([
+    {
+      name: 'explore',
+      description: 'Fast codebase search specialist for targeted exploration',
+    },
+  ]),
 
   parameters: taskInput,
   outputSchema: taskOutput,
   risk: 'safe',
 
   execute: async (params, signal, context) => {
-    const { prompt, thoroughness = 'medium' } = params;
+    const {
+      agent: agentName,
+      prompt,
+      maxIterations: callMaxIterations,
+    } = params;
 
-    // Get model, host, and safety config from context (passed from parent agent)
+    // --- Validate context ---
     const model = context?.model;
     const host = context?.host;
     const parentSafetyConfig = context?.safetyConfig;
+    const registry = context?.agentRegistry;
+    const runSubagent = context?.runSubagent;
 
     if (!model || !host || !parentSafetyConfig) {
       return {
         success: false,
         output: 'Task tool requires model, host, and safetyConfig in context',
+        agent: agentName,
         filesExplored: [],
         iterations: 0,
       };
     }
 
-    // Use config iteration limits if available, otherwise hardcoded defaults
-    const iterationLimits =
-      context?.toolsConfig?.task.iterationLimits ?? ITERATION_LIMITS;
+    if (!registry) {
+      return {
+        success: false,
+        output: 'Task tool requires agentRegistry in context',
+        agent: agentName,
+        filesExplored: [],
+        iterations: 0,
+      };
+    }
 
-    // Build the explore subagent prompt (with instructions from config)
-    const ctx = getDefaultContext(
+    if (!runSubagent) {
+      return {
+        success: false,
+        output: 'Task tool requires runSubagent in context',
+        agent: agentName,
+        filesExplored: [],
+        iterations: 0,
+      };
+    }
+
+    // --- Delegation depth guard ---
+    const currentDepth = context?.delegationDepth ?? 0;
+    if (currentDepth >= MAX_DELEGATION_DEPTH) {
+      return {
+        success: false,
+        output: `Maximum delegation depth (${MAX_DELEGATION_DEPTH}) exceeded. Cannot nest subagent calls deeper.`,
+        agent: agentName,
+        filesExplored: [],
+        iterations: 0,
+      };
+    }
+
+    // --- Resolve agent from registry ---
+    const targetAgent = registry.get(agentName);
+
+    if (!targetAgent) {
+      return {
+        success: false,
+        output: `Unknown agent: "${agentName}". Use one of the available agents listed in the tool description.`,
+        agent: agentName,
+        filesExplored: [],
+        iterations: 0,
+      };
+    }
+
+    // Verify agent is available as subagent
+    if (targetAgent.mode === 'primary') {
+      return {
+        success: false,
+        output: `Agent "${agentName}" is a primary agent and cannot be invoked as a subagent. Only agents with mode "subagent" or "all" can be delegated to.`,
+        agent: agentName,
+        filesExplored: [],
+        iterations: 0,
+      };
+    }
+
+    // --- Permission check ---
+    if (!isSubagentAllowed(context?.callerPermission, agentName)) {
+      return {
+        success: false,
+        output: `Permission denied: calling agent is not allowed to invoke "${agentName}" via task delegation.`,
+        agent: agentName,
+        filesExplored: [],
+        iterations: 0,
+      };
+    }
+
+    // --- Resolve iteration budget ---
+    const maxIterations = resolveMaxIterations(
+      callMaxIterations,
+      targetAgent.maxIterations,
+    );
+
+    // --- Build system prompt ---
+    const systemPromptOverride = buildSubagentPrompt(
+      targetAgent,
+      maxIterations,
       context?.projectRoot,
       context?.configInstructions,
     );
-    const systemPromptOverride = buildExplorePrompt(ctx, thoroughness);
 
-    // Track files explored by the subagent
+    // --- Run subagent ---
     const filesExplored: string[] = [];
 
     try {
-      const result = await runAgent({
-        model,
+      const result = await runSubagent({
+        model: targetAgent.model ?? model,
         host,
         userMessage: prompt,
         history: [],
-        mode: 'plan', // Always read-only for explore subagent
+        agent: targetAgent,
+        agentRegistry: registry,
+        delegationDepth: currentDepth + 1,
 
-        // Callbacks to track progress
-        onReasoningToken: () => {}, // Silent - don't stream to parent
-        onToolCall: (call) => {
-          // Track file reads
+        // Silent callbacks — don't stream to parent
+        onReasoningToken: () => {},
+        onToolCall: (call: {
+          function: { name: string; arguments: unknown };
+        }) => {
+          // Track file reads for reporting
           if (call.function.name === 'read_file') {
             const args = call.function.arguments as { path?: string };
             if (args.path) {
@@ -145,24 +325,26 @@ The tasks will run concurrently and you'll receive all results together.`,
         signal: signal ?? new AbortController().signal,
 
         config: {
-          maxIterations: iterationLimits[thoroughness],
+          maxIterations,
           loopDetection: true,
           loopThreshold: 2,
         },
 
+        temperature: targetAgent.temperature,
         safetyConfig: parentSafetyConfig,
         toolsConfig: context?.toolsConfig,
         configInstructions: context?.configInstructions,
         systemPromptOverride,
       });
 
-      // Check for error result
-      if ('type' in result) {
+      // Check for error result (AgentError has 'type', AgentResult has 'finalAnswer')
+      if (!('finalAnswer' in result)) {
+        const errorType = 'type' in result ? result.type : 'unknown';
+        const errorMessage = 'message' in result ? ` - ${result.message}` : '';
         return {
           success: false,
-          output: `Subagent error: ${result.type}${
-            'message' in result ? ` - ${result.message}` : ''
-          }`,
+          output: `Subagent error: ${errorType}${errorMessage}`,
+          agent: agentName,
           filesExplored,
           iterations: 0,
         };
@@ -171,13 +353,15 @@ The tasks will run concurrently and you'll receive all results together.`,
       return {
         success: true,
         output: result.finalAnswer,
-        filesExplored: [...new Set(filesExplored)], // Dedupe
+        agent: agentName,
+        filesExplored: [...new Set(filesExplored)],
         iterations: result.stats.totalIterations,
       };
     } catch (error) {
       return {
         success: false,
         output: `Task execution failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        agent: agentName,
         filesExplored,
         iterations: 0,
       };

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -57,6 +57,23 @@ export type ToolContext = {
   toolsConfig?: ToolsConfig;
   /** Instruction file paths from config (for subagent delegation) */
   configInstructions?: string[];
+  /** Agent registry for subagent resolution (task tool) */
+  agentRegistry?: import('./agents/registry').AgentRegistry;
+  /** Calling agent's permission config (for task permission checks) */
+  callerPermission?: import('./permission/types').PermissionConfig;
+  /**
+   * Subagent runner injected by the parent agent loop.
+   * Breaks the circular dependency: task.ts no longer imports runAgent directly.
+   * Typed loosely to avoid circular import (index.ts -> types.ts -> index.ts).
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: avoids circular type dependency
+  runSubagent?: (args: any) => Promise<AgentResult | AgentError>;
+  /**
+   * Current delegation depth (0 = top-level agent).
+   * Incremented by the task tool on each nested invocation.
+   * Capped at MAX_DELEGATION_DEPTH to prevent unbounded recursion.
+   */
+  delegationDepth?: number;
 };
 
 /**

--- a/tests/test-task-tool-unit.ts
+++ b/tests/test-task-tool-unit.ts
@@ -1,0 +1,716 @@
+/**
+ * Unit tests for the task tool rewrite (Story 5).
+ *
+ * Tests agent resolution, permission checks, maxIterations resolution,
+ * and dynamic description building. Does NOT test actual subagent execution
+ * (that requires Ollama) — focuses on the logic before runAgent() is called.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { AgentRegistry } from '../src/agent/agents/registry';
+import { ITERATION_PRESETS } from '../src/agent/agents/schema';
+import type { ResolvedAgent } from '../src/agent/agents/schema';
+import type { PermissionConfig } from '../src/agent/permission/types';
+import { DEFAULT_SAFETY_CONFIG } from '../src/agent/safety/types';
+import {
+  buildTaskToolDescription,
+  resolveMaxIterations,
+  MAX_DELEGATION_DEPTH,
+  taskTool,
+} from '../src/agent/tools/task';
+
+const TEST_SAFETY_CONFIG = { ...DEFAULT_SAFETY_CONFIG, projectRoot: '/tmp' };
+
+/** Mock runSubagent that always throws (simulates network failure). */
+const mockRunSubagent = async () => {
+  throw new Error('Connection refused (mock)');
+};
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+const exploreAgent: ResolvedAgent = {
+  name: 'explore',
+  description: 'Fast codebase search specialist',
+  mode: 'subagent',
+  disabled: false,
+  maxIterations: 'medium',
+  permission: {
+    '*': 'deny',
+    read: 'allow',
+    glob: 'allow',
+    grep: 'allow',
+    list: 'allow',
+  },
+  systemPrompt: '',
+  source: { type: 'builtin' },
+};
+
+const reviewerAgent: ResolvedAgent = {
+  name: 'reviewer',
+  description: 'Code review specialist',
+  mode: 'subagent',
+  disabled: false,
+  maxIterations: 'thorough',
+  permission: {
+    '*': 'deny',
+    read: 'allow',
+    glob: 'allow',
+    grep: 'allow',
+  },
+  systemPrompt: 'You are a code reviewer. Analyze code for issues.',
+  source: { type: 'project', path: '/project/.ollie/agents/reviewer.md' },
+};
+
+const buildAgent: ResolvedAgent = {
+  name: 'build',
+  description: 'Full-power implementation mode',
+  mode: 'primary',
+  disabled: false,
+  permission: { '*': 'allow' },
+  systemPrompt: '',
+  source: { type: 'builtin' },
+};
+
+const allModeAgent: ResolvedAgent = {
+  name: 'helper',
+  description: 'General helper that works in any context',
+  mode: 'all',
+  disabled: false,
+  maxIterations: 10,
+  permission: { '*': 'allow' },
+  systemPrompt: 'You are a general helper.',
+  source: { type: 'global', path: '/home/.config/ollie/agents/helper.md' },
+};
+
+function createRegistry(agents: ResolvedAgent[] = []): AgentRegistry {
+  return new AgentRegistry([
+    exploreAgent,
+    reviewerAgent,
+    buildAgent,
+    allModeAgent,
+    ...agents,
+  ]);
+}
+
+// ============================================================================
+// buildTaskToolDescription
+// ============================================================================
+
+describe('buildTaskToolDescription', () => {
+  it('lists available agents', () => {
+    const desc = buildTaskToolDescription([
+      { name: 'explore', description: 'Search specialist' },
+      { name: 'reviewer', description: 'Code reviewer' },
+    ]);
+
+    expect(desc).toContain('- explore: Search specialist');
+    expect(desc).toContain('- reviewer: Code reviewer');
+  });
+
+  it('produces valid description with single agent', () => {
+    const desc = buildTaskToolDescription([
+      { name: 'explore', description: 'Search specialist' },
+    ]);
+
+    expect(desc).toContain('Available agents:');
+    expect(desc).toContain('- explore: Search specialist');
+    expect(desc).toContain('agent (required)');
+  });
+
+  it('produces valid description with no agents', () => {
+    const desc = buildTaskToolDescription([]);
+
+    expect(desc).toContain('Available agents:');
+  });
+});
+
+// ============================================================================
+// Task tool execute — agent resolution
+// ============================================================================
+
+describe('task tool — agent resolution', () => {
+  it('returns error for unknown agent name', async () => {
+    const registry = createRegistry();
+    const result = await taskTool.execute(
+      { agent: 'nonexistent', description: 'test', prompt: 'do something' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        runSubagent: mockRunSubagent,
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Unknown agent');
+    expect(result.output).toContain('nonexistent');
+    expect(result.agent).toBe('nonexistent');
+  });
+
+  it('returns error for primary-only agent', async () => {
+    const registry = createRegistry();
+    const result = await taskTool.execute(
+      { agent: 'build', description: 'test', prompt: 'do something' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        runSubagent: mockRunSubagent,
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('primary agent');
+    expect(result.output).toContain('cannot be invoked as a subagent');
+    expect(result.agent).toBe('build');
+  });
+
+  it('allows agents with mode "all"', async () => {
+    const registry = createRegistry();
+    const result = await taskTool.execute(
+      { agent: 'helper', description: 'test', prompt: 'do something' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        runSubagent: mockRunSubagent,
+      },
+    );
+
+    // Will fail at mock level, not at resolution
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Task execution failed');
+    expect(result.output).not.toContain('Unknown agent');
+    expect(result.output).not.toContain('primary agent');
+    expect(result.agent).toBe('helper');
+  });
+
+  it('returns error when registry is missing from context', async () => {
+    const result = await taskTool.execute(
+      { agent: 'explore', description: 'test', prompt: 'do something' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('agentRegistry');
+  });
+
+  it('returns error when model/host/safetyConfig missing', async () => {
+    const result = await taskTool.execute(
+      { agent: 'explore', description: 'test', prompt: 'do something' },
+      undefined,
+      {},
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('requires model, host, and safetyConfig');
+  });
+});
+
+// ============================================================================
+// Task tool execute — permission checks
+// ============================================================================
+
+describe('task tool — permission checks', () => {
+  it('allows invocation when no caller permission (default allow)', async () => {
+    const registry = createRegistry();
+    const result = await taskTool.execute(
+      { agent: 'explore', description: 'test', prompt: 'find files' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        callerPermission: undefined,
+        runSubagent: mockRunSubagent,
+      },
+    );
+
+    // Passes permission check, fails at mock level
+    expect(result.output).not.toContain('Permission denied');
+  });
+
+  it('denies invocation when caller task permission denies agent', async () => {
+    const registry = createRegistry();
+    const callerPermission: PermissionConfig = {
+      task: { '*': 'deny' },
+    };
+
+    const result = await taskTool.execute(
+      { agent: 'explore', description: 'test', prompt: 'find files' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        callerPermission,
+        runSubagent: mockRunSubagent,
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Permission denied');
+    expect(result.output).toContain('explore');
+  });
+
+  it('allows specific agent when task permission uses pattern', async () => {
+    const registry = createRegistry();
+    const callerPermission: PermissionConfig = {
+      task: { '*': 'deny', explore: 'allow' },
+    };
+
+    const result = await taskTool.execute(
+      { agent: 'explore', description: 'test', prompt: 'find files' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        callerPermission,
+        runSubagent: mockRunSubagent,
+      },
+    );
+
+    // Passes permission, fails at mock level
+    expect(result.output).not.toContain('Permission denied');
+  });
+
+  it('denies non-allowed agent when task permission uses pattern', async () => {
+    const registry = createRegistry();
+    const callerPermission: PermissionConfig = {
+      task: { '*': 'deny', explore: 'allow' },
+    };
+
+    const result = await taskTool.execute(
+      { agent: 'reviewer', description: 'test', prompt: 'review code' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        callerPermission,
+        runSubagent: mockRunSubagent,
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Permission denied');
+    expect(result.output).toContain('reviewer');
+  });
+});
+
+// ============================================================================
+// maxIterations resolution
+// ============================================================================
+
+describe('task tool — maxIterations resolution', () => {
+  it('accepts numeric maxIterations', () => {
+    const result = taskTool.parameters.safeParse({
+      agent: 'explore',
+      description: 'test',
+      prompt: 'find files',
+      maxIterations: 20,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.maxIterations).toBe(20);
+    }
+  });
+
+  it('accepts preset string maxIterations', () => {
+    const result = taskTool.parameters.safeParse({
+      agent: 'explore',
+      description: 'test',
+      prompt: 'find files',
+      maxIterations: 'thorough',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.maxIterations).toBe('thorough');
+    }
+  });
+
+  it('maxIterations is optional', () => {
+    const result = taskTool.parameters.safeParse({
+      agent: 'explore',
+      description: 'test',
+      prompt: 'find files',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.maxIterations).toBeUndefined();
+    }
+  });
+
+  it('rejects invalid preset string', () => {
+    const result = taskTool.parameters.safeParse({
+      agent: 'explore',
+      description: 'test',
+      prompt: 'find files',
+      maxIterations: 'ultra',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects zero iterations', () => {
+    const result = taskTool.parameters.safeParse({
+      agent: 'explore',
+      description: 'test',
+      prompt: 'find files',
+      maxIterations: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative iterations', () => {
+    const result = taskTool.parameters.safeParse({
+      agent: 'explore',
+      description: 'test',
+      prompt: 'find files',
+      maxIterations: -5,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// Schema validation
+// ============================================================================
+
+describe('task tool — schema validation', () => {
+  it('requires agent field', () => {
+    const result = taskTool.parameters.safeParse({
+      description: 'test',
+      prompt: 'find files',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('requires prompt field', () => {
+    const result = taskTool.parameters.safeParse({
+      agent: 'explore',
+      description: 'test',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('requires description field', () => {
+    const result = taskTool.parameters.safeParse({
+      agent: 'explore',
+      prompt: 'find files',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty agent name', () => {
+    const result = taskTool.parameters.safeParse({
+      agent: '',
+      description: 'test',
+      prompt: 'find files',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts valid full input', () => {
+    const result = taskTool.parameters.safeParse({
+      agent: 'explore',
+      description: 'find auth logic',
+      prompt: 'Search for authentication and authorization code in the project',
+      maxIterations: 'thorough',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('output schema includes agent field', () => {
+    const result = taskTool.outputSchema.safeParse({
+      success: true,
+      output: 'found some files',
+      agent: 'explore',
+      filesExplored: ['/src/auth.ts'],
+      iterations: 3,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// Dynamic description with registry integration
+// ============================================================================
+
+describe('task tool — dynamic description via registry', () => {
+  it('registry.listForTask returns subagent and all-mode agents', () => {
+    const registry = createRegistry();
+    const agents = registry.listForTask();
+
+    const names = agents.map((a) => a.name);
+    expect(names).toContain('explore');
+    expect(names).toContain('reviewer');
+    expect(names).toContain('helper'); // mode: 'all'
+    expect(names).not.toContain('build'); // mode: 'primary'
+  });
+
+  it('registry.listForTask respects caller permission', () => {
+    const registry = createRegistry();
+    const callerPermission: PermissionConfig = {
+      task: { '*': 'deny', explore: 'allow' },
+    };
+
+    const agents = registry.listForTask(callerPermission);
+    const names = agents.map((a) => a.name);
+    expect(names).toContain('explore');
+    expect(names).not.toContain('reviewer');
+    expect(names).not.toContain('helper');
+  });
+
+  it('buildTaskToolDescription from registry agents', () => {
+    const registry = createRegistry();
+    const agents = registry.listForTask();
+    const desc = buildTaskToolDescription(agents);
+
+    expect(desc).toContain('- explore: Fast codebase search specialist');
+    expect(desc).toContain('- reviewer: Code review specialist');
+    expect(desc).toContain('- helper: General helper');
+    expect(desc).not.toContain('- build:');
+  });
+});
+
+// ============================================================================
+// resolveMaxIterations (direct tests)
+// ============================================================================
+
+describe('resolveMaxIterations', () => {
+  it('uses call override when provided (number)', () => {
+    expect(resolveMaxIterations(20, 'medium')).toBe(20);
+  });
+
+  it('uses call override when provided (preset)', () => {
+    expect(resolveMaxIterations('thorough', 'quick')).toBe(
+      ITERATION_PRESETS.thorough,
+    );
+  });
+
+  it('falls back to agent config when no call override', () => {
+    expect(resolveMaxIterations(undefined, 'quick')).toBe(
+      ITERATION_PRESETS.quick,
+    );
+  });
+
+  it('falls back to agent config number when no call override', () => {
+    expect(resolveMaxIterations(undefined, 12)).toBe(12);
+  });
+
+  it('falls back to default when both are undefined', () => {
+    expect(resolveMaxIterations(undefined, undefined)).toBe(
+      ITERATION_PRESETS.medium,
+    );
+  });
+
+  it('caps at MAX_SUBAGENT_ITERATIONS (50)', () => {
+    expect(resolveMaxIterations(100, undefined)).toBe(50);
+  });
+
+  it('caps agent config at MAX_SUBAGENT_ITERATIONS', () => {
+    expect(resolveMaxIterations(undefined, 999)).toBe(50);
+  });
+
+  it('call override of exactly 50 is not capped', () => {
+    expect(resolveMaxIterations(50, undefined)).toBe(50);
+  });
+});
+
+// ============================================================================
+// Delegation depth guard
+// ============================================================================
+
+describe('task tool — delegation depth guard', () => {
+  it('allows delegation at depth 0', async () => {
+    const registry = createRegistry();
+    const result = await taskTool.execute(
+      { agent: 'explore', description: 'test', prompt: 'find files' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        runSubagent: mockRunSubagent,
+        delegationDepth: 0,
+      },
+    );
+
+    // Passes depth check, fails at mock level
+    expect(result.output).not.toContain('delegation depth');
+  });
+
+  it('allows delegation at depth below max', async () => {
+    const registry = createRegistry();
+    const result = await taskTool.execute(
+      { agent: 'explore', description: 'test', prompt: 'find files' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        runSubagent: mockRunSubagent,
+        delegationDepth: MAX_DELEGATION_DEPTH - 1,
+      },
+    );
+
+    // Passes depth check, fails at mock level
+    expect(result.output).not.toContain('delegation depth');
+  });
+
+  it('rejects delegation at max depth', async () => {
+    const registry = createRegistry();
+    const result = await taskTool.execute(
+      { agent: 'explore', description: 'test', prompt: 'find files' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        runSubagent: mockRunSubagent,
+        delegationDepth: MAX_DELEGATION_DEPTH,
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('delegation depth');
+    expect(result.output).toContain(`${MAX_DELEGATION_DEPTH}`);
+  });
+
+  it('rejects delegation beyond max depth', async () => {
+    const registry = createRegistry();
+    const result = await taskTool.execute(
+      { agent: 'explore', description: 'test', prompt: 'find files' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        runSubagent: mockRunSubagent,
+        delegationDepth: MAX_DELEGATION_DEPTH + 5,
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('delegation depth');
+  });
+
+  it('defaults depth to 0 when not provided', async () => {
+    const registry = createRegistry();
+    const result = await taskTool.execute(
+      { agent: 'explore', description: 'test', prompt: 'find files' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        runSubagent: mockRunSubagent,
+        // no delegationDepth — should default to 0
+      },
+    );
+
+    // Passes depth check, fails at mock level
+    expect(result.output).not.toContain('delegation depth');
+  });
+});
+
+// ============================================================================
+// runSubagent integration
+// ============================================================================
+
+describe('task tool — runSubagent integration', () => {
+  it('returns success when runSubagent returns a valid result', async () => {
+    const registry = createRegistry();
+    const mockSuccess = async () => ({
+      finalAnswer: 'Found 3 relevant files in src/auth/',
+      steps: [],
+      messages: [],
+      stats: { totalIterations: 4, totalToolCalls: 6, totalDurationMs: 1200 },
+    });
+
+    const result = await taskTool.execute(
+      { agent: 'explore', description: 'test', prompt: 'find auth files' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        runSubagent: mockSuccess,
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe('Found 3 relevant files in src/auth/');
+    expect(result.agent).toBe('explore');
+    expect(result.iterations).toBe(4);
+  });
+
+  it('returns error when runSubagent returns an AgentError', async () => {
+    const registry = createRegistry();
+    const mockError = async () => ({
+      type: 'max_iterations' as const,
+      iterations: 15,
+      lastThought: 'Still searching...',
+      messages: [],
+    });
+
+    const result = await taskTool.execute(
+      { agent: 'explore', description: 'test', prompt: 'find auth files' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        runSubagent: mockError,
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Subagent error');
+    expect(result.output).toContain('max_iterations');
+  });
+
+  it('catches thrown errors from runSubagent', async () => {
+    const registry = createRegistry();
+    const result = await taskTool.execute(
+      { agent: 'explore', description: 'test', prompt: 'find files' },
+      undefined,
+      {
+        model: 'llama3',
+        host: 'http://localhost:11434',
+        safetyConfig: TEST_SAFETY_CONFIG,
+        agentRegistry: registry,
+        runSubagent: mockRunSubagent, // throws
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('Task execution failed');
+    expect(result.output).toContain('Connection refused');
+  });
+});


### PR DESCRIPTION
## Summary

Rewrites the task tool to support named agent delegation via the AgentRegistry, replacing the hardcoded explore-only path.

## Changes

### `src/agent/tools/task.ts` — Full rewrite
- **New schema**: `agent` (required), `maxIterations` (optional number or preset), removes `thoroughness`
- **Agent resolution**: Looks up target in registry, validates mode (subagent/all only)
- **Permission check**: Evaluates caller's `task` permission key against target agent name
- **Delegation depth guard**: `MAX_DELEGATION_DEPTH=3` prevents unbounded recursion
- **Iteration resolution**: call override → agent config → default (15), capped at 50
- **Subagent prompt**: Built-in explore gets dedicated prompt builder; others use `getSystemPromptForAgent()`
- **Dynamic description**: `buildTaskToolDescription()` exported for per-run tool schema generation
- **Robust discriminator**: Uses `'finalAnswer' in result` instead of fragile `'type' in result`

### `src/agent/tools/index.ts`
- `getToolsForAgent()` accepts optional `taskToolAgents` param — clones task tool description per-call (no shared state mutation)
- Removed `updateTaskToolDescription()` (was a race condition for concurrent agents)
- Cleaned up unused imports

### `src/agent/types.ts`
- Added `agentRegistry`, `callerPermission`, `runSubagent`, `delegationDepth` to `ToolContext`

### `src/agent/index.ts`
- Added `agentRegistry` and `delegationDepth` to `RunAgentArgs`
- Wires registry, permission, runSubagent, and depth through tool context
- Builds per-run subagent list for task tool description (no mutation)

### `tests/test-task-tool-unit.ts` — 43 tests
- Schema validation (required fields, maxIterations union type)
- Agent resolution (unknown, primary-only, all-mode)
- Permission checks (default allow, deny patterns, allow patterns)
- `resolveMaxIterations()` direct tests (priority chain, capping)
- Delegation depth guard (at/below/above max)
- runSubagent integration (success, error result, thrown exception)
- Dynamic description via registry

## Review findings addressed
- **High**: Eliminated mutable shared state — description cloned per-run
- **Medium**: Injected `runSubagent` via context — no circular dependency
- **Major**: Added recursion depth guard (`MAX_DELEGATION_DEPTH=3`)
- **Major**: Fixed fragile discriminator to use `'finalAnswer' in result`
- **Major**: Exported and directly tested `resolveMaxIterations()`

## Testing
- 164 tests pass (43 new + 121 existing)
- Type check clean (only pre-existing playground errors)

Closes #108