### PR TITLE
feat(tui): Phase 1 — Upgrade opentui to 0.1.107, solid-js to 1.9.12

### DIFF
--- a/TUI_OVERHAUL_PLAN.md
+++ b/TUI_OVERHAUL_PLAN.md
@@ -1,0 +1,496 @@
+# Plan: TUI Overhaul — OpenTUI Feature Adoption & Architecture Cleanup
+
+> Source: GitHub Issue #51 — "Adopt new @opentui features (post-Solid migration)"
+> Date: 2026-05-17
+> Current versions: `@opentui/core` ^0.1.97, `@opentui/solid` ^0.1.97, `solid-js` 1.9.9
+
+## Executive Summary
+
+This plan brings the OllieCode TUI from its current post-migration state to a polished,
+fully-modernized terminal interface. The work spans two major version upgrades
+(0.1.97 → 0.1.107 → 0.2.12), replaces custom workarounds with native opentui
+primitives, eliminates architectural debt from the React→Solid migration, and adopts
+every high-value feature identified in issue #51 plus features released since.
+
+The plan is organized as **vertical slices** — each phase delivers a complete,
+testable improvement. Phases are ordered by dependency (later phases build on earlier
+ones) and risk (safer changes first).
+
+---
+
+## Architectural Decisions
+
+These decisions apply across all phases:
+
+- **Runtime**: Bun (current). Phase 8 enables Node.js runtime support via 0.2.x platform layer.
+- **Framework**: `@opentui/solid` with SolidJS signals/stores for all reactivity.
+- **Keyboard architecture**: Native opentui keymap system replaces the custom `KeyboardFocusProvider` stack. `stopPropagation` + focusable elements replace userland gating.
+- **Markdown rendering**: `<markdown streaming>` element replaces `<code filetype="markdown">` for assistant messages (both streaming and finalized).
+- **Clipboard**: OSC 52 via `renderer.copyToClipboardOSC52()` replaces the cross-platform clipboard detection module.
+- **Theme detection**: `renderer.themeMode` + `renderer.on("theme_mode", ...)` replaces manual `COLORFGBG` env var parsing.
+- **Focus model**: Native `focusable` Box elements with auto-focus-on-click for interactive lists.
+- **Layout shorthands**: `marginX`/`marginY`/`paddingX`/`paddingY` preferred over explicit left/right/top/bottom pairs.
+- **Testing**: `testRender` from `@opentui/solid` for snapshot tests on all new/refactored components.
+
+---
+
+## Phase 1: Dependency Upgrade to 0.1.107 (Safe Semver Range)
+
+**Goal**: Get to the latest 0.1.x release without any code changes. Verify nothing breaks.
+
+### What to build
+
+Update `@opentui/core` and `@opentui/solid` to `0.1.107` (within the existing `^0.1.97`
+semver range, so this is effectively just a lockfile update). Update `solid-js` to
+`1.9.12` to match the peer dependency expectation. Run the full test suite and
+manually verify the TUI renders correctly.
+
+This phase is pure dependency management — no source code changes. It unlocks all
+features from v0.1.80 through v0.1.107 for subsequent phases.
+
+### Acceptance criteria
+
+- [ ] `bun install` resolves `@opentui/core@0.1.107` and `@opentui/solid@0.1.107`
+- [ ] `solid-js` updated to `1.9.12`
+- [ ] `babel-preset-solid` updated to match (1.9.12 if available, or compatible)
+- [ ] `bun run dev` launches without errors
+- [ ] All existing tests pass (`bun test`)
+- [ ] Type checking passes (`bun run check:types`)
+- [ ] Manual smoke test: start a chat session, send a message, receive streaming response, open command menu, open session picker, open config modal — all function correctly
+- [ ] No visual regressions in theme rendering
+
+---
+
+## Phase 2: Architecture Cleanup — DRY Modal Rendering & Component Extraction
+
+**Goal**: Eliminate duplicated JSX and establish clean component boundaries before feature work.
+
+### What to build
+
+The current `src/tui/index.tsx` renders all modals (ContextStatsModal, ConfigModal,
+McpStatusModal, KeyboardShortcutsModal, SessionPicker, ThemePicker) in both the
+welcome screen branch AND the chat screen branch (~80 lines duplicated). Extract this
+into a `<ModalLayer>` component that renders once, above both branches.
+
+Additionally, extract the welcome screen and chat screen into their own dedicated
+components (`<WelcomeScreen>` and `<ChatScreen>`) to reduce the size of `AppContent`
+and improve readability.
+
+Address the fragile prop extraction in `AppContent` (lines 72-74 where `props.config`,
+`props.configLayers`, `props.configWarnings` are assigned to plain variables). Convert
+these to proper accessor patterns or document why they're safe.
+
+### Acceptance criteria
+
+- [ ] New `<ModalLayer>` component renders all modals exactly once, regardless of app state (welcome vs chat)
+- [ ] `<WelcomeScreen>` component extracted with its own props interface
+- [ ] `<ChatScreen>` component extracted with its own props interface
+- [ ] `src/tui/index.tsx` reduced to composition of the above components plus context providers
+- [ ] No props destructuring introduced — all components access `props.foo` directly
+- [ ] Fragile `const model = props.config.model` patterns either converted to accessors or annotated with `// Static: set once at mount, never changes` with a comment explaining why
+- [ ] All existing functionality preserved — zero behavioral changes
+- [ ] Snapshot tests added for `<ModalLayer>`, `<WelcomeScreen>`, `<ChatScreen>`
+
+---
+
+## Phase 3: Streaming Markdown Rendering
+
+**Goal**: Replace raw `<text>` streaming with progressive markdown rendering using `<markdown streaming>`.
+
+### What to build
+
+Currently, streaming assistant responses display as plain unstyled text:
+```tsx
+<Show when={agent.streamingContent()}>
+  <box><text>{agent.streamingContent()}</text></box>
+</Show>
+```
+
+Replace this with the `<markdown>` element in streaming mode:
+```tsx
+<markdown
+  content={agent.streamingContent()}
+  syntaxStyle={markdownStyle()}
+  streaming={true}
+/>
+```
+
+This provides progressive rendering of headings, bold, code blocks, lists, and tables
+as tokens arrive — rather than the jarring switch from plain text to fully-formatted
+content when the message finalizes.
+
+Also migrate the finalized assistant message rendering in `assistant-message.tsx` from
+`<code filetype="markdown">` to `<markdown>` for consistency. The `<markdown>` element
+provides purpose-built markdown rendering (table alignment, list formatting, concealment
+of syntax characters) that `<code>` with a markdown filetype cannot match.
+
+### Acceptance criteria
+
+- [ ] Streaming responses render with markdown formatting (headings, bold, code fences, lists) in real-time
+- [ ] `streaming={true}` prop used during active streaming; switches to `streaming={false}` when finalized
+- [ ] Finalized messages in `assistant-message.tsx` use `<markdown>` instead of `<code filetype="markdown">`
+- [ ] `syntaxStyle` from the current theme is passed through correctly
+- [ ] Code blocks within markdown responses have syntax highlighting
+- [ ] No visual glitches during rapid token streaming
+- [ ] Tables render with proper column alignment (TextTable renderable, available since v0.1.82)
+- [ ] `selectable={true}` preserved for text selection in finalized messages
+- [ ] Performance: no noticeable frame drops during streaming (target: maintain 60fps)
+
+---
+
+## Phase 4: Replace Keyboard Focus Stack with Native Keymap System
+
+**Goal**: Remove the custom 163-line `keyboard-focus.tsx` and replace with opentui's native keyboard primitives.
+
+### What to build
+
+The current `KeyboardFocusProvider` registers 7+ `useKeyboard` handlers that ALL fire
+on every keypress, with userland `isActive()` gating to determine which handler
+should actually execute. This is replaced by:
+
+1. **`stopPropagation`** (available since v0.1.70) — Modal/overlay components stop
+   event propagation, preventing events from reaching underlying layers.
+
+2. **Focusable Box** (v0.1.76) — Interactive containers receive focus natively,
+   scoping keyboard events to the focused element tree.
+
+3. **Keymap system** (v0.1.98+) — Declarative key binding registration with
+   priority-based resolution, replacing the imperative switch statements.
+
+**Migration strategy:**
+
+- Remove `KeyboardFocusProvider`, `useFocusLayer`, `useScopedKeyboard` entirely
+- Each modal/overlay component uses `focusable` Box + `stopPropagation` in its keyboard handler
+- Global shortcuts (Ctrl+K, Ctrl+Y, Ctrl+P) registered via the keymap system with appropriate priority
+- Component-local shortcuts (arrow navigation in menus) scoped to their focusable container
+- The `APP` layer's keyboard handling moves into the main `<ChatScreen>` component directly
+
+### Acceptance criteria
+
+- [ ] `src/tui/keyboard/keyboard-focus.tsx` deleted entirely
+- [ ] `KeyboardFocusProvider` removed from the component tree
+- [ ] All imports of `useFocusLayer`, `useScopedKeyboard`, `FocusLayer` removed
+- [ ] Modals stop keyboard propagation — typing in a modal never triggers app-level shortcuts
+- [ ] Command menu stops propagation — arrow keys don't scroll the chat
+- [ ] File picker stops propagation — same isolation guarantee
+- [ ] Global shortcuts (Ctrl+K command menu, Ctrl+Y copy, Ctrl+P session picker) work from any context
+- [ ] Escape in a modal closes the modal without triggering app-level escape handling
+- [ ] Nested modals work correctly (e.g., opening theme picker from config modal)
+- [ ] No regressions in textarea input — typing in the input box works exactly as before
+- [ ] Performance: only 1 handler fires per keypress (not 7+)
+- [ ] Integration tests covering: modal open/close, command menu navigation, shortcut isolation
+
+---
+
+## Phase 5: OSC 52 Clipboard & Selection Improvements
+
+**Goal**: Replace the 129-line custom clipboard with native OSC 52 support.
+
+### What to build
+
+Remove `src/lib/clipboard.ts` which manually detects macOS (osascript), Linux
+(wl-copy/xclip/xsel), and Windows (PowerShell) clipboard commands. Replace with
+`renderer.copyToClipboardOSC52()` which works natively in all modern terminals
+including over SSH, inside tmux/screen, and in containerized environments.
+
+Also adopt the `useSelectionHandler` hook for text selection, replacing any manual
+selection + copy logic:
+
+```tsx
+useSelectionHandler((selection) => {
+  selection.copyToClipboard() // Uses OSC 52 internally
+})
+```
+
+Remove the `clipboardy` npm dependency.
+
+### Acceptance criteria
+
+- [ ] `src/lib/clipboard.ts` deleted
+- [ ] `clipboardy` removed from `package.json` dependencies
+- [ ] All clipboard copy operations use `renderer.copyToClipboardOSC52()`
+- [ ] `useSelectionHandler` hook integrated for text selection copy
+- [ ] Ctrl+Y (copy selection) works using OSC 52
+- [ ] Clipboard works over SSH sessions (where native commands would fail)
+- [ ] Clipboard works inside tmux/screen
+- [ ] Fallback behavior documented for terminals that don't support OSC 52
+- [ ] `renderer.isOsc52Supported()` checked before attempting copy, with user-facing notification on unsupported terminals
+
+---
+
+## Phase 6: Focusable Interactive Lists
+
+**Goal**: Simplify command menu, file picker, and session picker using native focus and `scrollChildIntoView`.
+
+### What to build
+
+The three interactive list components (command-menu, file-picker, session-picker) all
+share the same manual pattern:
+- `createSignal<number>` for `selectedIndex`
+- `useScopedKeyboard` with arrow/j/k handling
+- Manual `scrollIntoView` helper for scroll tracking
+- Imperative `scrollboxRef` management
+
+Replace with native opentui patterns:
+- `<box focusable>` for each list item
+- Auto-focus on click (v0.1.76)
+- `scrollChildIntoView` method on ScrollBox (v0.1.88) for automatic scroll tracking
+- Arrow key navigation handled by the focusable container's native behavior
+
+Extract a shared `<NavigableList>` component that encapsulates this pattern once,
+used by all three list UIs.
+
+### Acceptance criteria
+
+- [ ] `<NavigableList>` shared component created with props: `items`, `onSelect`, `renderItem`, `onCancel`
+- [ ] Command menu uses `<NavigableList>` — keyboard navigation works (arrows, j/k, enter, escape)
+- [ ] File picker uses `<NavigableList>` — same navigation, plus filtering
+- [ ] Session picker uses `<NavigableList>` — same navigation, plus rename/delete actions
+- [ ] Mouse click on any list item focuses and selects it (auto-focus on click)
+- [ ] Scroll automatically follows the focused item via `scrollChildIntoView`
+- [ ] Removed: manual `selectedIndex` signals from all three components
+- [ ] Removed: manual scroll offset calculations
+- [ ] Each list item has `focusable` Box wrapping
+- [ ] Visual focus indicator (border color change or highlight) on the focused item
+- [ ] Performance: instant focus transitions, no scroll jank
+
+---
+
+## Phase 7: Theme Detection & Layout Shorthands
+
+**Goal**: Adopt automatic dark/light detection and modernize layout props across the codebase.
+
+### What to build
+
+**Theme detection:**
+
+Replace the current `detectColorScheme()` in `src/design/theme.ts` which only checks
+the `COLORFGBG` env var (broken on most modern terminals) with the native opentui
+`renderer.themeMode` property and `theme_mode` event:
+
+```tsx
+const renderer = useRenderer()
+const [theme, setTheme] = createSignal(renderer.themeMode ?? "dark")
+onMount(() => {
+  renderer.on("theme_mode", (mode) => setTheme(mode))
+})
+```
+
+This uses Mode 2031 terminal query (v0.1.78) which works on iTerm2, Ghostty, Kitty,
+WezTerm, Windows Terminal, and most modern emulators.
+
+**Layout shorthands:**
+
+Audit all components and replace verbose padding/margin pairs with axis shorthands:
+- `paddingLeft={2} paddingRight={2}` → `paddingX={2}`
+- `marginTop={1} marginBottom={1}` → `marginY={1}`
+
+**autoFocus renderer option:**
+
+Configure the renderer with `autoFocus: true` to eliminate manual `.focus()` calls
+where appropriate.
+
+**Bottom title/alignment on Box:**
+
+Adopt the `bottomTitle` and `titleAlignment` props (v0.1.97) for status information
+on bordered containers.
+
+### Acceptance criteria
+
+- [ ] `detectColorScheme()` function removed from `src/design/theme.ts`
+- [ ] `ThemeProvider` uses `renderer.themeMode` for initial theme and listens for `theme_mode` events
+- [ ] Theme auto-switches when terminal dark/light mode changes (no restart required)
+- [ ] Manual theme selection still overrides auto-detection
+- [ ] All `paddingLeft`+`paddingRight` pairs replaced with `paddingX` where values match
+- [ ] All `paddingTop`+`paddingBottom` pairs replaced with `paddingY` where values match
+- [ ] All `marginLeft`+`marginRight` pairs replaced with `marginX` where values match
+- [ ] All `marginTop`+`marginBottom` pairs replaced with `marginY` where values match
+- [ ] Renderer created with `autoFocus: true`
+- [ ] Manual `.focus()` calls removed where `autoFocus` handles it
+- [ ] At least one `bottomTitle` usage added (e.g., status bar info on chat container)
+- [ ] No layout regressions — spacing identical before and after shorthand conversion
+
+---
+
+## Phase 8: Upgrade to @opentui 0.2.x
+
+**Goal**: Cross the breaking change boundary to access the latest platform features.
+
+### What to build
+
+Upgrade `@opentui/core` and `@opentui/solid` from `0.1.107` to `^0.2.12`. This
+involves handling two breaking changes:
+
+1. **Color metadata packing** (v0.2.0) — RGBA high bytes now carry metadata. Audit
+   all places where we create or manipulate `RGBA` values directly (theme.ts,
+   color.ts, utils.ts). The `RGBA` helper function should still work, but any
+   bitwise operations on raw color values need updating.
+
+2. **Platform abstraction** (v0.2.0+) — Bun-specific globals replaced with a platform
+   layer. Audit for any direct `Bun.file`, `bun:ffi`, or Bun-specific APIs that
+   opentui previously exposed. Our code uses `createCliRenderer` which should be
+   unaffected, but verify.
+
+Also adopt new 0.2.x features:
+- **OSC 8 hyperlinks** — URLs in markdown output become clickable terminal hyperlinks
+- **OSC notifications** — Notify the user when a long-running agent task completes
+- **`useFocus`/`useBlur` hooks** — React to terminal window focus changes
+- **`targetFps`/`maxFps` setters** — Dynamic frame rate adjustment for power saving
+
+### Acceptance criteria
+
+- [ ] `@opentui/core` and `@opentui/solid` updated to `^0.2.12`
+- [ ] `solid-js` confirmed at `1.9.12`
+- [ ] All `RGBA` color values verified — no corruption from metadata packing
+- [ ] Build succeeds with `bun run build`
+- [ ] Type checking passes
+- [ ] All tests pass
+- [ ] No Bun-specific API breakage from platform abstraction
+- [ ] URLs in markdown responses render as clickable OSC 8 hyperlinks
+- [ ] OSC notification sent when agent completes a tool call that took >5 seconds
+- [ ] `useFocus` hook used to pause/resume expensive rendering when terminal loses focus
+- [ ] Frame rate reduced to 15fps when terminal is unfocused (power saving)
+- [ ] Manual smoke test across: iTerm2, Ghostty, Kitty (if available), basic Terminal.app
+
+---
+
+## Phase 9: Terminal Focus Hooks & Performance Polish
+
+**Goal**: Leverage terminal focus events and finalize performance optimizations.
+
+### What to build
+
+Adopt the Solid-specific `useFocus`/`useBlur` hooks (v0.1.89) and the
+`targetFps`/`maxFps` setters (v0.1.93) for intelligent resource management:
+
+- When the terminal window loses focus, reduce rendering frequency
+- When regained, restore full frame rate
+- Pause streaming animations when unfocused
+- Resume state indicators (spinners, progress) immediately on refocus
+
+Additionally, audit the entire TUI for performance:
+- Ensure all `<For>` loops use stable references (not recreated arrays)
+- Verify memos are used for expensive derived computations
+- Check that effects have minimal dependency surfaces
+- Profile frame times during streaming and ensure consistent 60fps
+
+### Acceptance criteria
+
+- [ ] `useFocus` callback fires when terminal gains focus
+- [ ] `useBlur` callback fires when terminal loses focus
+- [ ] Renderer `targetFps` set to 15 when blurred, 60 when focused
+- [ ] Streaming token rendering does not drop frames (measured with `time-to-first-draw`)
+- [ ] No unnecessary signal re-creations in `<For>` loops
+- [ ] `createMemo` used for all derived values accessed more than once
+- [ ] No effects with overly broad dependency tracking
+- [ ] Spinner/loading animations pause when terminal unfocused
+- [ ] Memory stable during long chat sessions (no signal leaks)
+
+---
+
+## Phase 10: Plugins, Slots & Extensibility Foundation
+
+**Goal**: Adopt the Plugins/Slots system for future extensibility.
+
+### What to build
+
+The Plugins/Slots system (v0.1.88) provides a framework-level extensibility mechanism.
+Integrate it to allow:
+
+- Custom renderable slots in the status bar (e.g., git branch, token count, model name)
+- Plugin-based side panel content
+- Slot-based notification area for toast messages
+
+This is foundational work — it doesn't add user-visible features immediately but
+establishes the architecture for future plugin support (MCP tool output renderers,
+custom display components, etc.).
+
+### Acceptance criteria
+
+- [ ] Status bar uses named slots for each section (left, center, right)
+- [ ] At least one slot populated via the plugin registration API
+- [ ] Toast notification area managed via a slot
+- [ ] Side panel content configurable via slots
+- [ ] Plugin registration documented in code comments
+- [ ] No performance regression from slot overhead
+- [ ] Slot fallback identity caching active (v0.1.93 optimization)
+
+---
+
+## Phase 11: Comprehensive Testing & Documentation
+
+**Goal**: Full test coverage for all new components and refactored systems.
+
+### What to build
+
+Every phase above should include tests, but this phase adds comprehensive integration
+and snapshot testing to ensure long-term stability:
+
+- Snapshot tests for every component using `testRender`
+- Keyboard interaction tests: verify shortcut isolation, modal focus, navigation
+- Theme switching tests: verify all components respond to theme changes
+- Streaming tests: verify markdown rendering under rapid token delivery
+- Resize tests: verify responsive behavior at various terminal dimensions
+- Regression test suite: one test per bug fixed during this overhaul
+
+Update the `AGENTS.md` file with TUI development guidelines reflecting the new
+architecture (no more focus stack, use `<markdown>`, use focusable Box, etc.).
+
+### Acceptance criteria
+
+- [ ] Every component in `src/tui/components/` has at least one snapshot test
+- [ ] Keyboard shortcut isolation tested: modal open → type → verify no app-level side effects
+- [ ] Theme auto-detection tested with mock `renderer.themeMode`
+- [ ] Streaming markdown rendering tested with incremental content updates
+- [ ] Terminal resize tested at 80x24, 120x40, 40x12 (minimum viable)
+- [ ] `NavigableList` tested: arrow navigation, enter selection, escape cancel, mouse click
+- [ ] OSC 52 clipboard tested (mock renderer method)
+- [ ] `AGENTS.md` updated with TUI architecture section
+- [ ] All tests pass in CI (`bun test`)
+- [ ] Zero TODO/FIXME comments remain in `src/tui/`
+
+---
+
+## Dependency Summary
+
+| Phase | Depends on | Risk | Estimated Scope |
+|-------|-----------|------|-----------------|
+| 1 | None | Low | Lockfile + smoke test |
+| 2 | Phase 1 | Low | Refactoring only, no new APIs |
+| 3 | Phase 1 | Medium | New `<markdown>` element, streaming behavior |
+| 4 | Phase 1 | High | Complete keyboard architecture replacement |
+| 5 | Phase 4 | Low | Simple API swap (OSC 52) |
+| 6 | Phase 4 | Medium | Shared component + focusable Box |
+| 7 | Phase 1 | Low | Config + find-and-replace |
+| 8 | Phases 1-7 | High | Breaking version boundary |
+| 9 | Phase 8 | Low | Hooks + tuning |
+| 10 | Phase 8 | Medium | New architecture pattern |
+| 11 | All | Low | Testing + documentation |
+
+**Parallelization:** Phases 2, 3, and 7 can be worked in parallel after Phase 1.
+Phase 4 is the critical path — Phases 5 and 6 depend on it. Phase 8 is the second
+major gate — Phases 9 and 10 depend on it.
+
+---
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|-----------|
+| 0.2.x color packing breaks theme rendering | Phase 8 is isolated; full visual regression test before/after. Keep 0.1.107 branch as rollback. |
+| `stopPropagation` doesn't fully replace focus stack | Phase 4 is the most complex. Prototype the modal isolation pattern first in a branch before committing. |
+| `<markdown streaming>` has rendering glitches | Test with rapid token delivery (100+ tokens/sec). The element has been stable since v0.1.80 rebuild. |
+| Removing `clipboardy` breaks non-OSC52 terminals | Check `renderer.isOsc52Supported()` and log a warning. Document which terminals lack support. |
+| Performance regression from native focus | Benchmark keypress-to-render latency before and after Phase 4. Native should be faster (1 handler vs 7). |
+
+---
+
+## Out of Scope
+
+The following are explicitly **not** included in this plan:
+
+- Node.js runtime support (0.2.x enables it, but we remain Bun-only)
+- Native audio features (v0.2.4) — not relevant for a coding assistant
+- Custom inline highlighting callback — deferred to future search feature
+- `captureSpans`/`getSpanLines` — deferred to future testing enhancements
+- MCP tool output custom renderables — future work after Phase 10 slots are in place

--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,8 @@
       "name": "react",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@opentui/core": "^0.1.97",
-        "@opentui/solid": "^0.1.97",
+        "@opentui/core": "^0.1.107",
+        "@opentui/solid": "^0.1.107",
         "clipboardy": "^5.3.0",
         "commander": "^14.0.3",
         "diff": "^8.0.3",
@@ -15,7 +15,7 @@
         "gray-matter": "^4.0.3",
         "jsonc-parser": "^3.3.1",
         "ollama": "^0.6.3",
-        "solid-js": "1.9.9",
+        "solid-js": "1.9.12",
         "turndown": "^7.2.4",
         "zod": "^4.3.6",
       },
@@ -29,7 +29,7 @@
         "@types/bun": "latest",
         "@types/diff": "^8.0.0",
         "@types/turndown": "^5.0.6",
-        "babel-preset-solid": "1.9.9",
+        "babel-preset-solid": "1.9.12",
         "promptfoo": "^0.120.24",
       },
       "peerDependencies": {
@@ -632,21 +632,21 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.39.0", "", {}, "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg=="],
 
-    "@opentui/core": ["@opentui/core@0.1.97", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.97", "@opentui/core-darwin-x64": "0.1.97", "@opentui/core-linux-arm64": "0.1.97", "@opentui/core-linux-x64": "0.1.97", "@opentui/core-win32-arm64": "0.1.97", "@opentui/core-win32-x64": "0.1.97", "bun-webgpu": "0.1.5", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-2ENH0Dc4NUAeHeeQCQhF1lg68RuyntOUP68UvortvDqTz/hqLG0tIwF+DboCKtWi8Nmao4SAQEJ7lfmyQNEDOQ=="],
+    "@opentui/core": ["@opentui/core@0.1.107", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.107", "@opentui/core-darwin-x64": "0.1.107", "@opentui/core-linux-arm64": "0.1.107", "@opentui/core-linux-x64": "0.1.107", "@opentui/core-win32-arm64": "0.1.107", "@opentui/core-win32-x64": "0.1.107", "bun-webgpu": "0.1.7", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-gadu9EtNR+sOGyHN0buZryllavkWHRkCcX4yW/1ldp/l7HGS52hvkjYmo+74cuzUcfds/5Rbw2cgiy0Z7RxXmQ=="],
 
-    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.1.97", "", { "os": "darwin", "cpu": "arm64" }, "sha512-t7oMGEfMPQsqLEx7/rPqv/UGJ+vqhe4RWHRRQRYcuHuLKssZ2S8P9mSS7MBPtDqGcxg4PosCrh5nHYeZ94EXUw=="],
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.1.107", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Yqt2/9Ntw0IdtPA/qmHvXCE16y4Jq5/btCmuzN9/opzqZ5rYGYYVtiBii3LezGcTZYuJQZthjvh8MLPXXwA2EQ=="],
 
-    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.1.97", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZuPWAawlVat6ZHb8vaH/CVUeGwI0pI4vd+6zz1ZocZn95ZWJztfyhzNZOJrq1WjHmUROieJ7cOuYUZfvYNuLrg=="],
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.1.107", "", { "os": "darwin", "cpu": "x64" }, "sha512-p6yeHsIWRLy/J30nZTyUuwgFYEpk8NS0H0Cmh9P8a1+eHA406MMMP4FAC0YpqlF4SHb7R7LNkUSsfCx9yMtS8w=="],
 
-    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.1.97", "", { "os": "linux", "cpu": "arm64" }, "sha512-QXxhz654vXgEu2wrFFFFnrSWbyk6/r6nXNnDTcMRWofdMZQLx87NhbcsErNmz9KmFdzoPiQSmlpYubLflKKzqQ=="],
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.1.107", "", { "os": "linux", "cpu": "arm64" }, "sha512-w6MpRTd06KUH4KdgH4x7rVB2I67KE62w3W3jQVBDEMeJejdJVOSwwUdgaTY9ffoHglcZc3WA2PFH1PCpgzna4A=="],
 
-    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.1.97", "", { "os": "linux", "cpu": "x64" }, "sha512-v3z0QWpRS3p8blE/A7pTu15hcFMtSndeiYhRxhrjp6zAhQ+UlruQs9DAG1ifSuVO1RJJ0pUKklFivdbu0pMzuw=="],
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.1.107", "", { "os": "linux", "cpu": "x64" }, "sha512-oxKbIpWZRgY+8KQZ9dXq8lzDEhMVpBMCiZGDiHtK8/DP1MvK5kFE/vtwgUK9YkmT4OSgZsFeojjvyePXV+PcfQ=="],
 
-    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.1.97", "", { "os": "win32", "cpu": "arm64" }, "sha512-o/m9mD1dvOCwkxOUUyoEILl+d6tzh/85foJc4uqjXYi71NNcwg8u+Eq3/gdHuSKnlT1pusCPKoS1IDuBvZE24A=="],
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.1.107", "", { "os": "win32", "cpu": "arm64" }, "sha512-T7hbLgoTkb5eAsP5GJdTRyDl48WI/hMEtj+BGlIITzSaOBSN7ZPCeblcfUz+uXrdF6g3dF1a9uyEQSJlzeGaKA=="],
 
-    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.1.97", "", { "os": "win32", "cpu": "x64" }, "sha512-Rwp7JOwrYm4wtzPHY2vv+2l91LXmKSI7CtbmWN1sSUGhBPtPGSvfwux3W5xaAZQa2KPEXicPjaKJZc+pob3YRg=="],
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.1.107", "", { "os": "win32", "cpu": "x64" }, "sha512-e/uFLPyKK/hFDvDZtTxp6L3Zx0FWuZv5Gf2qIKf/7FAAadD0hala+K41OJAmYWxu1X3cT5XozKCT8gN/S1N08A=="],
 
-    "@opentui/solid": ["@opentui/solid@0.1.97", "", { "dependencies": { "@babel/core": "7.28.0", "@babel/preset-typescript": "7.27.1", "@opentui/core": "0.1.97", "babel-plugin-module-resolver": "5.0.2", "babel-preset-solid": "1.9.10", "entities": "7.0.1", "s-js": "^0.4.9" }, "peerDependencies": { "solid-js": "1.9.11" } }, "sha512-ma/uihG38F+6oLJVD8yR7z82FWmR8QhfesNV5SBXbN74riMCRyy6kyQ6SI4xs4ykt9BbZOjrKLq+Xt/0Pd0SJQ=="],
+    "@opentui/solid": ["@opentui/solid@0.1.107", "", { "dependencies": { "@babel/core": "7.28.0", "@babel/preset-typescript": "7.27.1", "@opentui/core": "0.1.107", "babel-plugin-module-resolver": "5.0.2", "babel-preset-solid": "1.9.12", "entities": "7.0.1", "s-js": "^0.4.9" }, "peerDependencies": { "solid-js": "1.9.12" } }, "sha512-zi5wbb5SsU2x70XZ1L+fBGz2BdA1TzBIgqjAlmWqOrtQai4rQzexSuz8kMzKNP6uIsDsDu3FGtgr3G9bTt9Gxg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -906,7 +906,7 @@
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
@@ -936,11 +936,11 @@
 
     "axios": ["axios@1.13.2", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA=="],
 
-    "babel-plugin-jsx-dom-expressions": ["babel-plugin-jsx-dom-expressions@0.40.3", "", { "dependencies": { "@babel/helper-module-imports": "7.18.6", "@babel/plugin-syntax-jsx": "^7.18.6", "@babel/types": "^7.20.7", "html-entities": "2.3.3", "parse5": "^7.1.2" }, "peerDependencies": { "@babel/core": "^7.20.12" } }, "sha512-5HOwwt0BYiv/zxl7j8Pf2bGL6rDXfV6nUhLs8ygBX+EFJXzBPHM/euj9j/6deMZ6wa52Wb2PBaAV5U/jKwIY1w=="],
+    "babel-plugin-jsx-dom-expressions": ["babel-plugin-jsx-dom-expressions@0.40.7", "", { "dependencies": { "@babel/helper-module-imports": "7.18.6", "@babel/plugin-syntax-jsx": "^7.18.6", "@babel/types": "^7.20.7", "html-entities": "2.3.3", "parse5": "^7.1.2" }, "peerDependencies": { "@babel/core": "^7.20.12" } }, "sha512-/O6JWUmjv03OI9lL2ry9bUjpD5S3PclM55RRJEyCdcFZ5W2SEA/59d+l2hNsk3gI6kiWRdRPdOtqZmsQzFN1pQ=="],
 
     "babel-plugin-module-resolver": ["babel-plugin-module-resolver@5.0.2", "", { "dependencies": { "find-babel-config": "^2.1.1", "glob": "^9.3.3", "pkg-up": "^3.1.0", "reselect": "^4.1.7", "resolve": "^1.22.8" } }, "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg=="],
 
-    "babel-preset-solid": ["babel-preset-solid@1.9.9", "", { "dependencies": { "babel-plugin-jsx-dom-expressions": "^0.40.1" }, "peerDependencies": { "@babel/core": "^7.0.0", "solid-js": "^1.9.8" }, "optionalPeers": ["solid-js"] }, "sha512-pCnxWrciluXCeli/dj5PIEHgbNzim3evtTn12snjqqg8QZWJNMjH1AWIp4iG/tbVjqQ72aBEymMSagvmgxubXw=="],
+    "babel-preset-solid": ["babel-preset-solid@1.9.12", "", { "dependencies": { "babel-plugin-jsx-dom-expressions": "^0.40.6" }, "peerDependencies": { "@babel/core": "^7.0.0", "solid-js": "^1.9.12" }, "optionalPeers": ["solid-js"] }, "sha512-LLqnuKVDlKpyBlMPcH6qEvs/wmS9a+NczppxJ3ryS/c0O5IiSFOIBQi9GzyiGDSbcJpx4Gr87jyFTos1MyEuWg=="],
 
     "balanced-match": ["balanced-match@4.0.2", "", { "dependencies": { "jackspeak": "^4.2.3" } }, "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg=="],
 
@@ -998,15 +998,15 @@
 
     "bun-types": ["bun-types@1.2.20", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-pxTnQYOrKvdOwyiyd/7sMt9yFOenN004Y6O4lCcCUoKVej48FS5cvTw9geRaEcB9TsDZaJKAxPTVvi8tFsVuXA=="],
 
-    "bun-webgpu": ["bun-webgpu@0.1.5", "", { "dependencies": { "@webgpu/types": "^0.1.60" }, "optionalDependencies": { "bun-webgpu-darwin-arm64": "^0.1.5", "bun-webgpu-darwin-x64": "^0.1.5", "bun-webgpu-linux-x64": "^0.1.5", "bun-webgpu-win32-x64": "^0.1.5" } }, "sha512-91/K6S5whZKX7CWAm9AylhyKrLGRz6BUiiPiM/kXadSnD4rffljCD/q9cNFftm5YXhx4MvLqw33yEilxogJvwA=="],
+    "bun-webgpu": ["bun-webgpu@0.1.7", "", { "dependencies": { "@webgpu/types": "^0.1.60" }, "optionalDependencies": { "bun-webgpu-darwin-arm64": "^0.1.7", "bun-webgpu-darwin-x64": "^0.1.7", "bun-webgpu-linux-x64": "^0.1.7", "bun-webgpu-win32-x64": "^0.1.7" } }, "sha512-KUxUp+oQIf7pPBMD4Hv1TUu7DWaOZ4ciKulTk9to9+Uc8yHoYrMW7L2SJCJ4FHHkywgf/7aLRgRx0b7i6DvGIQ=="],
 
-    "bun-webgpu-darwin-arm64": ["bun-webgpu-darwin-arm64@0.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lIsDkPzJzPl6yrB5CUOINJFPnTRv6fF/Q8J1mAr43ogSp86WZEg9XZKaT6f3EUJ+9ETogGoMnoj1q0AwHUTbAQ=="],
+    "bun-webgpu-darwin-arm64": ["bun-webgpu-darwin-arm64@0.1.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mRrFFyHzPWjsTRidAZBRcu808CPQBOUL0P6b4nxLhp+XHcV/mbUHERZMgW9s58tsojQfSdzschiQa8q+JCgRWA=="],
 
-    "bun-webgpu-darwin-x64": ["bun-webgpu-darwin-x64@0.1.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-uEddf5U7GvKIkM/BV18rUKtYHL6d0KeqBjNHwfqDH9QgEo9KVSKvJXS5I/sMefk5V5pIYE+8tQhtrREevhocng=="],
+    "bun-webgpu-darwin-x64": ["bun-webgpu-darwin-x64@0.1.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-g0NXGNgvaVCSH/jCWWlfdiquOHkbUN6vP4zqzSkIxWKQeLnqm3oADcok7SO3yIgI7v5mKpRc/ks7NDEKNH+jNQ=="],
 
-    "bun-webgpu-linux-x64": ["bun-webgpu-linux-x64@0.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-Y/f15j9r8ba0xUz+3lATtS74OE+PPzQXO7Do/1eCluJcuOlfa77kMjvBK/ShWnem3Y9xqi59pebTPOGRB+CaJA=="],
+    "bun-webgpu-linux-x64": ["bun-webgpu-linux-x64@0.1.7", "", { "os": "linux", "cpu": "x64" }, "sha512-UEP7UZdEhx9otvkZczjsszL8ZVlrODANQvgl+C88/bNVmxDoFi7w1fWzGi1sZyakiETjmtFDq2/xCLhbSZxjqw=="],
 
-    "bun-webgpu-win32-x64": ["bun-webgpu-win32-x64@0.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-MHSFAKqizISb+C5NfDrFe3g0Al5Njnu0j/A+oO2Q+bIWX+fUYjBSowiYE1ZXJx65KuryuB+tiM7Qh6cQbVvkEg=="],
+    "bun-webgpu-win32-x64": ["bun-webgpu-win32-x64@0.1.7", "", { "os": "win32", "cpu": "x64" }, "sha512-KZktiFkBz6sN7PEm1NVdeaLP5Q5X/PlSHZqefY4nNuWtf0LNvh54NhZe7yVv/Plz/nGbv92b0KHMBY3ki/pp6g=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -1178,7 +1178,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
 
@@ -1994,9 +1994,9 @@
 
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
-    "seroval": ["seroval@1.3.2", "", {}, "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ=="],
+    "seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
 
-    "seroval-plugins": ["seroval-plugins@1.3.3", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-16OL3NnUBw8JG1jBLUoZJsLnQq0n5Ua6aHalhJK4fMQkz1lqR7Osz1sA30trBtd9VUDc2NgkuRCn8+/pBwqZ+w=="],
+    "seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
@@ -2050,7 +2050,7 @@
 
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
-    "solid-js": ["solid-js@1.9.9", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.3.0", "seroval-plugins": "~1.3.0" } }, "sha512-A0ZBPJQldAeGCTW0YRYJmt7RCeh5rbFfPZ2aOttgYnctHE7HgKeHCBB/PVc2P7eOfmNXqMFFFoYYdm3S4dcbkA=="],
+    "solid-js": ["solid-js@1.9.12", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -2076,13 +2076,13 @@
 
     "stopwords-iso": ["stopwords-iso@1.1.0", "", {}, "sha512-I6GPS/E0zyieHehMRPQcqkiBMJKGgLta+1hREixhoLPqEA0AlVFiC43dl8uPpmkkeRdDMzYRWFWk5/l9x7nmNg=="],
 
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -2398,8 +2398,6 @@
 
     "@opentui/solid/@babel/preset-typescript": ["@babel/preset-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ=="],
 
-    "@opentui/solid/babel-preset-solid": ["babel-preset-solid@1.9.10", "", { "dependencies": { "babel-plugin-jsx-dom-expressions": "^0.40.3" }, "peerDependencies": { "@babel/core": "^7.0.0", "solid-js": "^1.9.10" }, "optionalPeers": ["solid-js"] }, "sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ=="],
-
     "@redis/client/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "@types/diff/diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
@@ -2415,6 +2413,10 @@
     "basic-auth/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "cli-progress/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cli-table3/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cli-truncate/string-width": ["string-width@8.1.1", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw=="],
 
@@ -2441,6 +2443,8 @@
     "engine.io/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "engine.io-client/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "enquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "execa/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
@@ -2588,6 +2592,12 @@
 
     "socks/ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "subsume/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "tar/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
@@ -2608,11 +2618,11 @@
 
     "winston/@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
 
-    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@aws-crypto/crc32/@aws-sdk/types/@smithy/types": ["@smithy/types@4.11.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA=="],
 
@@ -2642,7 +2652,13 @@
 
     "babel-plugin-module-resolver/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
-    "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+    "cli-progress/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cli-progress/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cli-table3/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cli-table3/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "color/color-convert/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
@@ -2654,6 +2670,8 @@
 
     "engine.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
+    "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
@@ -2661,8 +2679,6 @@
     "http-server/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "ibm-cloud-sdk-core/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
-
-    "ink/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -2675,8 +2691,6 @@
     "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "ora/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
-
-    "ora/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "pkg-up/find-up/locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
 
@@ -2708,17 +2722,17 @@
 
     "socket.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "unzipper/fs-extra/jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
     "unzipper/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
-    "widest-line/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
@@ -2732,13 +2746,11 @@
 
     "babel-plugin-module-resolver/glob/path-scurry/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
-    "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "cli-progress/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ink/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "cli-table3/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ora/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
-
-    "ora/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "pkg-up/find-up/locate-path/p-locate": ["p-locate@3.0.0", "", { "dependencies": { "p-limit": "^2.0.0" } }, "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ=="],
 
@@ -2752,15 +2764,11 @@
 
     "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
     "babel-plugin-module-resolver/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "puppeteer-extra-plugin-user-data-dir/rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "rimraf/glob/jackspeak/@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "rimraf/glob/jackspeak/@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "rimraf/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
@@ -2769,7 +2777,5 @@
     "puppeteer-extra-plugin-user-data-dir/rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "rimraf/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "rimraf/glob/jackspeak/@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/bun": "latest",
     "@types/diff": "^8.0.0",
     "@types/turndown": "^5.0.6",
-    "babel-preset-solid": "1.9.9",
+    "babel-preset-solid": "1.9.12",
     "promptfoo": "^0.120.24"
   },
   "peerDependencies": {
@@ -66,8 +66,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@opentui/core": "^0.1.97",
-    "@opentui/solid": "^0.1.97",
+    "@opentui/core": "^0.1.107",
+    "@opentui/solid": "^0.1.107",
     "clipboardy": "^5.3.0",
     "commander": "^14.0.3",
     "diff": "^8.0.3",
@@ -75,7 +75,7 @@
     "gray-matter": "^4.0.3",
     "jsonc-parser": "^3.3.1",
     "ollama": "^0.6.3",
-    "solid-js": "1.9.9",
+    "solid-js": "1.9.12",
     "turndown": "^7.2.4",
     "zod": "^4.3.6"
   }


### PR DESCRIPTION
## Summary

Upgrades OpenTUI and Solid dependencies to unlock all features from v0.1.80–v0.1.107 for the TUI overhaul tracked in #51.

## Changes

| Dependency | Before | After |
|---|---|---|
| `@opentui/core` | ^0.1.97 | ^0.1.107 |
| `@opentui/solid` | ^0.1.97 | ^0.1.107 |
| `solid-js` | 1.9.9 | 1.9.12 |
| `babel-preset-solid` | 1.9.9 | 1.9.12 |

## Unlocked Features (for subsequent phases)

- MarkdownRenderable streaming rebuild (v0.1.80)
- TextTable renderable (v0.1.82)
- Plugins/Slots system (v0.1.88)
- `scrollChildIntoView` for ScrollBox (v0.1.88)
- `useFocus`/`useBlur` terminal focus hooks (v0.1.89)
- `targetFps`/`maxFps` setters (v0.1.93)
- Bottom title/alignment for Box (v0.1.97)
- Keymap system (v0.1.98+)

## Also included

- `TUI_OVERHAUL_PLAN.md` — comprehensive 11-phase plan for the full TUI overhaul

## Verification

- [x] `bun run check:types` passes (only pre-existing playground errors)
- [x] `bun run build` succeeds
- [x] No test regressions

Ref: #51