### PR TITLE
refactor(tui): Phase 2 — Extract ModalLayer, WelcomeScreen, ChatScreen

### DIFF
--- a/src/tui/components/chat-screen.tsx
+++ b/src/tui/components/chat-screen.tsx
@@ -1,0 +1,248 @@
+/**
+ * ChatScreen — displayed when messages exist in the session.
+ * Shows the scrollable message list, input box, side panel, and overlays.
+ */
+
+import type { Accessor } from 'solid-js';
+import { For, Show } from 'solid-js';
+import type { McpStatusMap } from '../../agent/mcp/types';
+import { useTheme } from '../../design';
+import type {
+  AgentMode,
+  CompactionSummaryDisplayMessage,
+  DisplayMessage,
+  ErrorDisplayMessage,
+  Status,
+  TextareaRef,
+  Todo,
+  ToolDisplayMessage,
+} from '../types';
+import type { ContextStats } from '../../lib/tokenizer';
+import { fastScrollAccel } from '../utils';
+import { AssistantMessage } from './assistant-message';
+import { CommandMenu, type SlashCommand } from './command-menu';
+import { CompactionSummary } from './compaction-summary';
+import { ContextInfoNotification } from './context-info-notification';
+import { ErrorMessage } from './error-message';
+import { FilePicker } from './file-picker';
+import { InputBox } from './input-box';
+import { SidePanel } from './side-panel';
+import { ToastNotification } from './toast-notification';
+import { ToolMessage } from './tool-message';
+import { UserMessage } from './user-message';
+
+export interface ChatScreenProps {
+  // Messages
+  displayMessages: Accessor<DisplayMessage[]>;
+  streamingContent: Accessor<string | null>;
+
+  // Tool confirmation
+  confirmingToolId: Accessor<string | null>;
+  onToolConfirmation: (
+    response: import('../types').ConfirmationResponse,
+  ) => void;
+  toolsExpanded: Accessor<boolean>;
+
+  // Input box
+  model: string;
+  status: Accessor<Status>;
+  mode: Accessor<AgentMode>;
+  getTextareaRef: () => TextareaRef;
+  getStatus: () => Status;
+  onSubmit: (message: string) => void;
+  onRef: (el: NonNullable<TextareaRef>) => void;
+  inputDisabled: Accessor<boolean>;
+
+  // Command menu
+  showCommandMenu: Accessor<boolean>;
+  slashCommands: SlashCommand[];
+  commandFilter: Accessor<string>;
+  commandSelectedIndex: Accessor<number>;
+  onCommandSelect: (command: SlashCommand) => void;
+  onCommandMenuCancel: () => void;
+  onCommandIndexChange: (index: number) => void;
+
+  // File picker
+  showFilePicker: Accessor<boolean>;
+  files: Accessor<string[]>;
+  fileFilter: Accessor<string>;
+  fileSelectedIndex: Accessor<number>;
+  onFileSelect: (file: string) => void;
+  onFilePickerCancel: () => void;
+  onFileIndexChange: (index: number) => void;
+
+  // Context info
+  contextInfo: Accessor<string | null>;
+
+  // Side panel
+  sidebarStats: Accessor<ContextStats | null>;
+  sidebarTodos: Accessor<Todo[]>;
+  mcpStatus: Accessor<McpStatusMap>;
+  mcpConnecting: Accessor<boolean>;
+
+  // Toast
+  toast: Accessor<string | null>;
+  toastDuration: number;
+  onToastDismiss: () => void;
+}
+
+export function ChatScreen(props: ChatScreenProps) {
+  const { tokens } = useTheme();
+
+  return (
+    <box
+      style={{ backgroundColor: tokens.bgBase }}
+      flexDirection="row"
+      flexGrow={1}
+      flexShrink={1}
+    >
+      <box
+        flexDirection="column"
+        flexGrow={1}
+        flexShrink={1}
+        paddingTop={1}
+        paddingLeft={2}
+        paddingRight={2}
+      >
+        <scrollbox
+          flexGrow={1}
+          flexShrink={1}
+          stickyScroll={true}
+          stickyStart="bottom"
+          scrollAcceleration={fastScrollAccel}
+        >
+          <box flexDirection="column" flexGrow={1} paddingRight={2}>
+            <For each={props.displayMessages()}>
+              {(msg) => (
+                <box marginBottom={1}>
+                  <Show when={msg.type === 'user' && msg}>
+                    {(userMsg: () => DisplayMessage) => {
+                      const m = userMsg() as {
+                        type: 'user';
+                        content: string;
+                        attachedFiles?: string[];
+                      };
+                      return (
+                        <UserMessage
+                          content={m.content}
+                          attachedFiles={m.attachedFiles}
+                        />
+                      );
+                    }}
+                  </Show>
+                  <Show when={msg.type === 'assistant' && msg}>
+                    {(assistantMsg: () => DisplayMessage) => {
+                      const m = assistantMsg() as {
+                        type: 'assistant';
+                        content: string;
+                      };
+                      return <AssistantMessage content={m.content} />;
+                    }}
+                  </Show>
+                  <Show when={msg.type === 'tool'}>
+                    <ToolMessage
+                      message={msg as ToolDisplayMessage}
+                      isActiveConfirmation={
+                        props.confirmingToolId() ===
+                        (msg as ToolDisplayMessage).id
+                      }
+                      onConfirmationResponse={(response) => {
+                        props.onToolConfirmation(response);
+                      }}
+                      expanded={props.toolsExpanded()}
+                    />
+                  </Show>
+                  <Show when={msg.type === 'compaction_summary' && msg}>
+                    {(summaryMsg: () => CompactionSummaryDisplayMessage) => (
+                      <CompactionSummary
+                        content={summaryMsg().content}
+                        compactedCount={summaryMsg().compactedCount}
+                      />
+                    )}
+                  </Show>
+                  <Show when={msg.type === 'error' && msg}>
+                    {(errorMsg: () => ErrorDisplayMessage) => (
+                      <ErrorMessage
+                        errorType={errorMsg().errorType}
+                        content={errorMsg().content}
+                      />
+                    )}
+                  </Show>
+                </box>
+              )}
+            </For>
+
+            <Show when={props.streamingContent()}>
+              <box>
+                <text>{props.streamingContent()}</text>
+              </box>
+            </Show>
+          </box>
+        </scrollbox>
+
+        <box flexDirection="column" flexShrink={0} position="relative">
+          <Show when={props.contextInfo()}>
+            {(info: () => string) => (
+              <ContextInfoNotification message={info()} />
+            )}
+          </Show>
+
+          <Show when={props.showCommandMenu()}>
+            <CommandMenu
+              commands={props.slashCommands}
+              filter={props.commandFilter()}
+              selectedIndex={props.commandSelectedIndex()}
+              onSelect={props.onCommandSelect}
+              onCancel={props.onCommandMenuCancel}
+              onIndexChange={props.onCommandIndexChange}
+              bottom={5}
+            />
+          </Show>
+
+          <Show when={props.showFilePicker()}>
+            <FilePicker
+              files={props.files()}
+              filter={props.fileFilter()}
+              selectedIndex={props.fileSelectedIndex()}
+              onSelect={props.onFileSelect}
+              onCancel={props.onFilePickerCancel}
+              onIndexChange={props.onFileIndexChange}
+              bottom={5}
+            />
+          </Show>
+
+          <InputBox
+            id="chat-textarea"
+            model={props.model}
+            status={props.status()}
+            mode={props.mode()}
+            getTextareaRef={props.getTextareaRef}
+            getStatus={props.getStatus}
+            onSubmit={props.onSubmit}
+            onRef={props.onRef}
+            disabled={props.inputDisabled()}
+            suppressSubmit={props.showFilePicker()}
+          />
+        </box>
+      </box>
+
+      <SidePanel
+        contextStats={props.sidebarStats()}
+        todos={props.sidebarTodos()}
+        mcpStatus={props.mcpStatus()}
+        mcpConnecting={props.mcpConnecting()}
+        width={40}
+      />
+
+      <Show when={props.toast()}>
+        {(msg: () => string) => (
+          <ToastNotification
+            message={msg()}
+            duration={props.toastDuration}
+            onDismiss={props.onToastDismiss}
+          />
+        )}
+      </Show>
+    </box>
+  );
+}

--- a/src/tui/components/index.ts
+++ b/src/tui/components/index.ts
@@ -37,6 +37,8 @@ export {
 export { Modal } from './modal';
 export { SessionPicker } from './session-picker';
 // Layout components
+export { ChatScreen, type ChatScreenProps } from './chat-screen';
+export { ModalLayer, type ModalLayerProps } from './modal-layer';
 export { SidePanel } from './side-panel';
 export { StatusBar } from './status-bar';
 export { ThemePicker } from './theme-picker';
@@ -46,3 +48,4 @@ export {
 } from './toast-notification';
 export { ToolMessage, type ToolMessageProps } from './tool-message';
 export { UserMessage, type UserMessageProps } from './user-message';
+export { WelcomeScreen, type WelcomeScreenProps } from './welcome-screen';

--- a/src/tui/components/modal-layer.tsx
+++ b/src/tui/components/modal-layer.tsx
@@ -1,0 +1,113 @@
+/**
+ * ModalLayer — renders all modals and pickers exactly once.
+ * Eliminates duplication of modal rendering across welcome/chat screens.
+ */
+
+import type { Accessor } from 'solid-js';
+import { Show } from 'solid-js';
+import type { McpStatusMap } from '../../agent/mcp/types';
+import type { McpManager } from '../../agent/mcp/manager';
+import type { ConfigLayer } from '../../config/merge';
+import type { ResolvedConfig } from '../../config/schema';
+import { listSessions } from '../../session';
+import type { ContextStats, Session } from '../types';
+import { ContextStatsModal } from './context-stats-modal';
+import { ConfigModal } from './config-modal';
+import { McpStatusModal } from './mcp-status-modal';
+import { KeyboardShortcutsModal } from './keyboard-shortcuts-modal';
+import { SessionPicker } from './session-picker';
+import { ThemePicker } from './theme-picker';
+
+export interface ModalLayerProps {
+  // Context stats modal
+  showContextStats: Accessor<boolean>;
+  contextStats: Accessor<ContextStats | null>;
+  modelName: string;
+  onContextStatsClose: () => void;
+
+  // Config modal
+  showConfigModal: Accessor<boolean>;
+  config: ResolvedConfig;
+  /** Static: set once at mount, never changes */
+  configLayers: ConfigLayer[];
+  /** Static: set once at mount, never changes */
+  configWarnings: string[];
+  onConfigModalClose: () => void;
+
+  // MCP status modal
+  showMcpModal: Accessor<boolean>;
+  mcpStatus: Accessor<McpStatusMap>;
+  mcpManager: McpManager;
+  onMcpModalClose: () => void;
+
+  // Keyboard shortcuts modal
+  showHelp: Accessor<boolean>;
+  onHelpClose: () => void;
+
+  // Session picker
+  showSessionPicker: Accessor<boolean>;
+  projectPath: string;
+  sessionListLimit: number;
+  onSessionSelect: (session: Session) => void;
+  onSessionPickerCancel: () => void;
+  onSessionsChanged: () => void;
+
+  // Theme picker
+  showThemePicker: Accessor<boolean>;
+  onThemeSelect: (theme: string) => void;
+  onThemePickerCancel: () => void;
+}
+
+export function ModalLayer(props: ModalLayerProps) {
+  return (
+    <>
+      <Show when={props.showContextStats() && props.contextStats()}>
+        {(stats: () => ContextStats) => (
+          <ContextStatsModal
+            stats={stats()}
+            modelName={props.modelName}
+            onClose={props.onContextStatsClose}
+          />
+        )}
+      </Show>
+
+      <Show when={props.showConfigModal()}>
+        <ConfigModal
+          config={props.config}
+          layers={props.configLayers}
+          warnings={props.configWarnings}
+          onClose={props.onConfigModalClose}
+        />
+      </Show>
+
+      <Show when={props.showMcpModal()}>
+        <McpStatusModal
+          mcpStatus={props.mcpStatus()}
+          manager={props.mcpManager}
+          onClose={props.onMcpModalClose}
+        />
+      </Show>
+
+      <Show when={props.showHelp()}>
+        <KeyboardShortcutsModal onClose={props.onHelpClose} />
+      </Show>
+
+      <Show when={props.showSessionPicker()}>
+        <SessionPicker
+          sessions={listSessions({ limit: props.sessionListLimit })}
+          projectPath={props.projectPath}
+          onSelect={props.onSessionSelect}
+          onCancel={props.onSessionPickerCancel}
+          onSessionsChanged={props.onSessionsChanged}
+        />
+      </Show>
+
+      <Show when={props.showThemePicker()}>
+        <ThemePicker
+          onSelect={props.onThemeSelect}
+          onCancel={props.onThemePickerCancel}
+        />
+      </Show>
+    </>
+  );
+}

--- a/src/tui/components/welcome-screen.tsx
+++ b/src/tui/components/welcome-screen.tsx
@@ -1,0 +1,141 @@
+/**
+ * WelcomeScreen — displayed when no messages exist in the session.
+ * Shows the ASCII banner, input box, and contextual overlays.
+ */
+
+import type { Accessor } from 'solid-js';
+import { Show } from 'solid-js';
+import { RGBA } from '@opentui/core';
+import { useTheme } from '../../design';
+import type { AgentMode, Status } from '../types';
+import type { TextareaRef } from '../types';
+import { CommandMenu, type SlashCommand } from './command-menu';
+import { ContextInfoNotification } from './context-info-notification';
+import { FilePicker } from './file-picker';
+import { InputBox } from './input-box';
+import { ToastNotification } from './toast-notification';
+
+export interface WelcomeScreenProps {
+  // Input box
+  model: string;
+  status: Accessor<Status>;
+  mode: Accessor<AgentMode>;
+  getTextareaRef: () => TextareaRef;
+  getStatus: () => Status;
+  onSubmit: (message: string) => void;
+  onRef: (el: NonNullable<TextareaRef>) => void;
+  inputDisabled: Accessor<boolean>;
+
+  // Command menu
+  showCommandMenu: Accessor<boolean>;
+  slashCommands: SlashCommand[];
+  commandFilter: Accessor<string>;
+  commandSelectedIndex: Accessor<number>;
+  onCommandSelect: (command: SlashCommand) => void;
+  onCommandMenuCancel: () => void;
+  onCommandIndexChange: (index: number) => void;
+
+  // File picker
+  showFilePicker: Accessor<boolean>;
+  files: Accessor<string[]>;
+  fileFilter: Accessor<string>;
+  fileSelectedIndex: Accessor<number>;
+  onFileSelect: (file: string) => void;
+  onFilePickerCancel: () => void;
+  onFileIndexChange: (index: number) => void;
+
+  // Context info
+  contextInfo: Accessor<string | null>;
+
+  // Toast
+  toast: Accessor<string | null>;
+  toastDuration: number;
+  onToastDismiss: () => void;
+}
+
+export function WelcomeScreen(props: WelcomeScreenProps) {
+  const { tokens } = useTheme();
+
+  return (
+    <box
+      style={{ backgroundColor: tokens.bgBase }}
+      flexDirection="column"
+      flexGrow={1}
+      alignItems="center"
+      justifyContent="center"
+    >
+      <box flexDirection="row">
+        <ascii_font
+          text="Ollie"
+          font="tiny"
+          color={RGBA.fromHex(tokens.primaryBase)}
+        />
+        <text> </text>
+        <ascii_font
+          text="Code"
+          font="tiny"
+          color={RGBA.fromHex(tokens.textBase)}
+        />
+      </box>
+
+      <Show when={props.contextInfo()}>
+        {(info: () => string) => (
+          <box marginTop={1}>
+            <ContextInfoNotification message={info()} />
+          </box>
+        )}
+      </Show>
+
+      <box flexDirection="column" marginTop={2} width={80} position="relative">
+        <Show when={props.showCommandMenu()}>
+          <CommandMenu
+            commands={props.slashCommands}
+            filter={props.commandFilter()}
+            selectedIndex={props.commandSelectedIndex()}
+            onSelect={props.onCommandSelect}
+            onCancel={props.onCommandMenuCancel}
+            onIndexChange={props.onCommandIndexChange}
+            bottom={5}
+            width={80}
+          />
+        </Show>
+
+        <Show when={props.showFilePicker()}>
+          <FilePicker
+            files={props.files()}
+            filter={props.fileFilter()}
+            selectedIndex={props.fileSelectedIndex()}
+            onSelect={props.onFileSelect}
+            onCancel={props.onFilePickerCancel}
+            onIndexChange={props.onFileIndexChange}
+            bottom={5}
+            width={80}
+          />
+        </Show>
+
+        <InputBox
+          id="greeting-textarea"
+          model={props.model}
+          status={props.status()}
+          mode={props.mode()}
+          getTextareaRef={props.getTextareaRef}
+          getStatus={props.getStatus}
+          onSubmit={props.onSubmit}
+          onRef={props.onRef}
+          disabled={props.inputDisabled()}
+          suppressSubmit={props.showFilePicker()}
+        />
+      </box>
+
+      <Show when={props.toast()}>
+        {(msg: () => string) => (
+          <ToastNotification
+            message={msg()}
+            duration={props.toastDuration}
+            onDismiss={props.onToastDismiss}
+          />
+        )}
+      </Show>
+    </box>
+  );
+}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -1,34 +1,14 @@
 /**
  * TUI Entry Point.
- * Main application component with all hooks and UI rendering.
+ * Main application component — composes ModalLayer, WelcomeScreen, and ChatScreen.
  */
 
 import type { TextareaRenderable } from '@opentui/core';
-import { RGBA } from '@opentui/core';
-import { createMemo, createSignal, For, Show } from 'solid-js';
+import { createMemo, createSignal, Show } from 'solid-js';
 import { extractTuiConfig } from '../config/resolve';
-import { ThemeProvider, useTheme } from '../design';
-import { listSessions } from '../session';
+import { ThemeProvider } from '../design';
 import { FocusLayer, KeyboardFocusProvider, useFocusLayer } from './keyboard';
-import {
-  AssistantMessage,
-  CommandMenu,
-  CompactionSummary,
-  ConfigModal,
-  ContextInfoNotification,
-  ContextStatsModal,
-  ErrorMessage,
-  FilePicker,
-  InputBox,
-  KeyboardShortcutsModal,
-  McpStatusModal,
-  SessionPicker,
-  SidePanel,
-  ThemePicker,
-  ToastNotification,
-  ToolMessage,
-  UserMessage,
-} from './components';
+import { ChatScreen, ModalLayer, WelcomeScreen } from './components';
 import {
   useAgentContext,
   useAgentSubmit,
@@ -39,8 +19,7 @@ import {
   useSession,
 } from './hooks';
 import { useMessageStore } from './hooks/use-message-store';
-import type { AppProps, DisplayMessage, Status } from './types';
-import { fastScrollAccel } from './utils';
+import type { AppProps, Status } from './types';
 
 /** Prompt template for /init command - creates/updates AGENTS.md */
 const INIT_PROMPT_TEMPLATE = `Please analyze this codebase and create an AGENTS.md file containing:
@@ -69,10 +48,10 @@ export function App(props: AppProps) {
 }
 
 function AppContent(props: AppProps) {
+  // Static: set once at mount, never changes (config is resolved before render)
   const configLayers = props.configLayers ?? [];
   const configWarnings = props.configWarnings ?? [];
   const model = props.config.model;
-  const { tokens } = useTheme();
 
   // Register the "app" focus layer — active when no modal/overlay is open
   useFocusLayer(FocusLayer.APP);
@@ -170,363 +149,120 @@ function AppContent(props: AppProps) {
     tuiConfig: tuiConfig(),
   });
 
-  // Render welcome screen if no messages
+  // Derived: is input disabled on welcome screen
+  const welcomeInputDisabled = () =>
+    session.showSessionPicker() || session.showThemePicker();
+
+  // Derived: is input disabled on chat screen
+  const chatInputDisabled = () =>
+    !!agent.confirmingToolId() ||
+    session.showSessionPicker() ||
+    session.showThemePicker();
+
   return (
-    <Show
-      when={session.displayMessages().length > 0}
-      fallback={
-        <box
-          style={{ backgroundColor: tokens.bgBase }}
-          flexDirection="column"
-          flexGrow={1}
-          alignItems="center"
-          justifyContent="center"
-        >
-          <Show when={context.showContextStats() && context.contextStats()}>
-            {(stats: () => import('./types').ContextStats) => (
-              <ContextStatsModal
-                stats={stats()}
-                modelName={model}
-                onClose={context.handleContextStatsClose}
-              />
-            )}
-          </Show>
+    <>
+      <ModalLayer
+        showContextStats={context.showContextStats}
+        contextStats={context.contextStats}
+        modelName={model}
+        onContextStatsClose={context.handleContextStatsClose}
+        showConfigModal={showConfigModal}
+        config={props.config}
+        configLayers={configLayers}
+        configWarnings={configWarnings}
+        onConfigModalClose={() => setShowConfigModal(false)}
+        showMcpModal={showMcpModal}
+        mcpStatus={mcp.mcpStatus}
+        mcpManager={mcp.manager}
+        onMcpModalClose={() => setShowMcpModal(false)}
+        showHelp={showHelp}
+        onHelpClose={() => setShowHelp(false)}
+        showSessionPicker={session.showSessionPicker}
+        projectPath={props.projectPath}
+        sessionListLimit={tuiConfig().sessionListLimit}
+        onSessionSelect={session.handleSessionSelect}
+        onSessionPickerCancel={session.handleSessionPickerCancel}
+        onSessionsChanged={session.handleSessionsChanged}
+        showThemePicker={session.showThemePicker}
+        onThemeSelect={session.handleThemeSelect}
+        onThemePickerCancel={session.handleThemePickerCancel}
+      />
 
-          <Show when={showConfigModal()}>
-            <ConfigModal
-              config={props.config}
-              layers={configLayers}
-              warnings={configWarnings}
-              onClose={() => setShowConfigModal(false)}
-            />
-          </Show>
-
-          <Show when={showMcpModal()}>
-            <McpStatusModal
-              mcpStatus={mcp.mcpStatus()}
-              manager={mcp.manager}
-              onClose={() => setShowMcpModal(false)}
-            />
-          </Show>
-
-          <Show when={showHelp()}>
-            <KeyboardShortcutsModal onClose={() => setShowHelp(false)} />
-          </Show>
-
-          <box flexDirection="row">
-            <ascii_font
-              text="Ollie"
-              font="tiny"
-              color={RGBA.fromHex(tokens.primaryBase)}
-            />
-            <text> </text>
-            <ascii_font
-              text="Code"
-              font="tiny"
-              color={RGBA.fromHex(tokens.textBase)}
-            />
-          </box>
-
-          <Show when={session.showSessionPicker()}>
-            <SessionPicker
-              sessions={listSessions({ limit: tuiConfig().sessionListLimit })}
-              projectPath={props.projectPath}
-              onSelect={session.handleSessionSelect}
-              onCancel={session.handleSessionPickerCancel}
-              onSessionsChanged={session.handleSessionsChanged}
-            />
-          </Show>
-
-          <Show when={session.showThemePicker()}>
-            <ThemePicker
-              onSelect={session.handleThemeSelect}
-              onCancel={session.handleThemePickerCancel}
-            />
-          </Show>
-
-          <Show when={context.contextInfo()}>
-            {(info: () => string) => (
-              <box marginTop={1}>
-                <ContextInfoNotification message={info()} />
-              </box>
-            )}
-          </Show>
-
-          <box
-            flexDirection="column"
-            marginTop={2}
-            width={80}
-            position="relative"
-          >
-            <Show when={commands.showCommandMenu()}>
-              <CommandMenu
-                commands={commands.slashCommands}
-                filter={commands.commandFilter()}
-                selectedIndex={commands.commandSelectedIndex()}
-                onSelect={commands.handleCommandSelect}
-                onCancel={commands.handleCommandMenuCancel}
-                onIndexChange={commands.handleCommandIndexChange}
-                bottom={5}
-                width={80}
-              />
-            </Show>
-
-            <Show when={filePicker.showFilePicker()}>
-              <FilePicker
-                files={filePicker.files()}
-                filter={filePicker.fileFilter()}
-                selectedIndex={filePicker.fileSelectedIndex()}
-                onSelect={filePicker.handleFileSelect}
-                onCancel={filePicker.handleFilePickerCancel}
-                onIndexChange={filePicker.handleFileIndexChange}
-                bottom={5}
-                width={80}
-              />
-            </Show>
-
-            <InputBox
-              id="greeting-textarea"
-              model={model}
-              status={agent.status()}
-              mode={session.mode()}
-              getTextareaRef={getTextareaRef}
-              getStatus={getStatus}
-              onSubmit={agent.handleSubmit}
-              onRef={(el) => {
-                textareaRef = el;
-              }}
-              disabled={
-                session.showSessionPicker() || session.showThemePicker()
-              }
-              suppressSubmit={filePicker.showFilePicker()}
-            />
-          </box>
-
-          <Show when={toast()}>
-            {(msg: () => string) => (
-              <ToastNotification
-                message={msg()}
-                duration={tuiConfig().toastDuration}
-                onDismiss={() => setToast(null)}
-              />
-            )}
-          </Show>
-        </box>
-      }
-    >
-      {/* Chat screen with messages */}
-      <box
-        style={{ backgroundColor: tokens.bgBase }}
-        flexDirection="row"
-        flexGrow={1}
-        flexShrink={1}
+      <Show
+        when={session.displayMessages().length > 0}
+        fallback={
+          <WelcomeScreen
+            model={model}
+            status={agent.status}
+            mode={session.mode}
+            getTextareaRef={getTextareaRef}
+            getStatus={getStatus}
+            onSubmit={agent.handleSubmit}
+            onRef={(el) => {
+              textareaRef = el;
+            }}
+            inputDisabled={welcomeInputDisabled}
+            showCommandMenu={commands.showCommandMenu}
+            slashCommands={commands.slashCommands}
+            commandFilter={commands.commandFilter}
+            commandSelectedIndex={commands.commandSelectedIndex}
+            onCommandSelect={commands.handleCommandSelect}
+            onCommandMenuCancel={commands.handleCommandMenuCancel}
+            onCommandIndexChange={commands.handleCommandIndexChange}
+            showFilePicker={filePicker.showFilePicker}
+            files={filePicker.files}
+            fileFilter={filePicker.fileFilter}
+            fileSelectedIndex={filePicker.fileSelectedIndex}
+            onFileSelect={filePicker.handleFileSelect}
+            onFilePickerCancel={filePicker.handleFilePickerCancel}
+            onFileIndexChange={filePicker.handleFileIndexChange}
+            contextInfo={context.contextInfo}
+            toast={toast}
+            toastDuration={tuiConfig().toastDuration}
+            onToastDismiss={() => setToast(null)}
+          />
+        }
       >
-        <Show when={context.showContextStats() && context.contextStats()}>
-          {(stats: () => import('./types').ContextStats) => (
-            <ContextStatsModal
-              stats={stats()}
-              modelName={model}
-              onClose={context.handleContextStatsClose}
-            />
-          )}
-        </Show>
-
-        <Show when={showConfigModal()}>
-          <ConfigModal
-            config={props.config}
-            layers={configLayers}
-            warnings={configWarnings}
-            onClose={() => setShowConfigModal(false)}
-          />
-        </Show>
-
-        <Show when={showMcpModal()}>
-          <McpStatusModal
-            mcpStatus={mcp.mcpStatus()}
-            manager={mcp.manager}
-            onClose={() => setShowMcpModal(false)}
-          />
-        </Show>
-
-        <Show when={showHelp()}>
-          <KeyboardShortcutsModal onClose={() => setShowHelp(false)} />
-        </Show>
-
-        <Show when={session.showSessionPicker()}>
-          <SessionPicker
-            sessions={listSessions({ limit: tuiConfig().sessionListLimit })}
-            projectPath={props.projectPath}
-            onSelect={session.handleSessionSelect}
-            onCancel={session.handleSessionPickerCancel}
-            onSessionsChanged={session.handleSessionsChanged}
-          />
-        </Show>
-
-        <Show when={session.showThemePicker()}>
-          <ThemePicker
-            onSelect={session.handleThemeSelect}
-            onCancel={session.handleThemePickerCancel}
-          />
-        </Show>
-
-        <box
-          flexDirection="column"
-          flexGrow={1}
-          flexShrink={1}
-          paddingTop={1}
-          paddingLeft={2}
-          paddingRight={2}
-        >
-          <scrollbox
-            flexGrow={1}
-            flexShrink={1}
-            stickyScroll={true}
-            stickyStart="bottom"
-            scrollAcceleration={fastScrollAccel}
-          >
-            <box flexDirection="column" flexGrow={1} paddingRight={2}>
-              <For each={session.displayMessages()}>
-                {(msg) => (
-                  <box marginBottom={1}>
-                    <Show when={msg.type === 'user' && msg}>
-                      {(userMsg: () => DisplayMessage) => {
-                        const m = userMsg() as {
-                          type: 'user';
-                          content: string;
-                          attachedFiles?: string[];
-                        };
-                        return (
-                          <UserMessage
-                            content={m.content}
-                            attachedFiles={m.attachedFiles}
-                          />
-                        );
-                      }}
-                    </Show>
-                    <Show when={msg.type === 'assistant' && msg}>
-                      {(assistantMsg: () => DisplayMessage) => {
-                        const m = assistantMsg() as {
-                          type: 'assistant';
-                          content: string;
-                        };
-                        return <AssistantMessage content={m.content} />;
-                      }}
-                    </Show>
-                    <Show when={msg.type === 'tool'}>
-                      <ToolMessage
-                        message={msg as import('./types').ToolDisplayMessage}
-                        isActiveConfirmation={
-                          agent.confirmingToolId() ===
-                          (msg as import('./types').ToolDisplayMessage).id
-                        }
-                        onConfirmationResponse={(response) => {
-                          agent.handleToolConfirmation(response);
-                        }}
-                        expanded={toolsExpanded()}
-                      />
-                    </Show>
-                    <Show when={msg.type === 'compaction_summary' && msg}>
-                      {(
-                        summaryMsg: () => import('./types').CompactionSummaryDisplayMessage,
-                      ) => (
-                        <CompactionSummary
-                          content={summaryMsg().content}
-                          compactedCount={summaryMsg().compactedCount}
-                        />
-                      )}
-                    </Show>
-                    <Show when={msg.type === 'error' && msg}>
-                      {(
-                        errorMsg: () => import('./types').ErrorDisplayMessage,
-                      ) => (
-                        <ErrorMessage
-                          errorType={errorMsg().errorType}
-                          content={errorMsg().content}
-                        />
-                      )}
-                    </Show>
-                  </box>
-                )}
-              </For>
-
-              <Show when={agent.streamingContent()}>
-                <box>
-                  <text>{agent.streamingContent()}</text>
-                </box>
-              </Show>
-            </box>
-          </scrollbox>
-
-          <box flexDirection="column" flexShrink={0} position="relative">
-            <Show when={context.contextInfo()}>
-              {(info: () => string) => (
-                <ContextInfoNotification message={info()} />
-              )}
-            </Show>
-
-            <Show when={commands.showCommandMenu()}>
-              <CommandMenu
-                commands={commands.slashCommands}
-                filter={commands.commandFilter()}
-                selectedIndex={commands.commandSelectedIndex()}
-                onSelect={commands.handleCommandSelect}
-                onCancel={commands.handleCommandMenuCancel}
-                onIndexChange={commands.handleCommandIndexChange}
-                bottom={5}
-              />
-            </Show>
-
-            <Show when={filePicker.showFilePicker()}>
-              <FilePicker
-                files={filePicker.files()}
-                filter={filePicker.fileFilter()}
-                selectedIndex={filePicker.fileSelectedIndex()}
-                onSelect={filePicker.handleFileSelect}
-                onCancel={filePicker.handleFilePickerCancel}
-                onIndexChange={filePicker.handleFileIndexChange}
-                bottom={5}
-              />
-            </Show>
-
-            <InputBox
-              id="chat-textarea"
-              model={model}
-              status={agent.status()}
-              mode={session.mode()}
-              getTextareaRef={getTextareaRef}
-              getStatus={getStatus}
-              onSubmit={agent.handleSubmit}
-              onRef={(el) => {
-                textareaRef = el;
-              }}
-              disabled={
-                !!agent.confirmingToolId() ||
-                session.showSessionPicker() ||
-                session.showThemePicker()
-              }
-              suppressSubmit={filePicker.showFilePicker()}
-            />
-          </box>
-        </box>
-
-        <SidePanel
-          contextStats={context.sidebarStats()}
-          todos={session.sidebarTodos()}
-          mcpStatus={mcp.mcpStatus()}
-          mcpConnecting={mcp.connecting()}
-          width={40}
+        <ChatScreen
+          displayMessages={session.displayMessages}
+          streamingContent={agent.streamingContent}
+          confirmingToolId={agent.confirmingToolId}
+          onToolConfirmation={agent.handleToolConfirmation}
+          toolsExpanded={toolsExpanded}
+          model={model}
+          status={agent.status}
+          mode={session.mode}
+          getTextareaRef={getTextareaRef}
+          getStatus={getStatus}
+          onSubmit={agent.handleSubmit}
+          onRef={(el) => {
+            textareaRef = el;
+          }}
+          inputDisabled={chatInputDisabled}
+          showCommandMenu={commands.showCommandMenu}
+          slashCommands={commands.slashCommands}
+          commandFilter={commands.commandFilter}
+          commandSelectedIndex={commands.commandSelectedIndex}
+          onCommandSelect={commands.handleCommandSelect}
+          onCommandMenuCancel={commands.handleCommandMenuCancel}
+          onCommandIndexChange={commands.handleCommandIndexChange}
+          showFilePicker={filePicker.showFilePicker}
+          files={filePicker.files}
+          fileFilter={filePicker.fileFilter}
+          fileSelectedIndex={filePicker.fileSelectedIndex}
+          onFileSelect={filePicker.handleFileSelect}
+          onFilePickerCancel={filePicker.handleFilePickerCancel}
+          onFileIndexChange={filePicker.handleFileIndexChange}
+          contextInfo={context.contextInfo}
+          sidebarStats={context.sidebarStats}
+          sidebarTodos={session.sidebarTodos}
+          mcpStatus={mcp.mcpStatus}
+          mcpConnecting={mcp.connecting}
+          toast={toast}
+          toastDuration={tuiConfig().toastDuration}
+          onToastDismiss={() => setToast(null)}
         />
-
-        <Show when={toast()}>
-          {(msg: () => string) => (
-            <ToastNotification
-              message={msg()}
-              duration={tuiConfig().toastDuration}
-              onDismiss={() => setToast(null)}
-            />
-          )}
-        </Show>
-      </box>
-    </Show>
+      </Show>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Deduplicates modal rendering and establishes clean component boundaries in the TUI, per Phase 2 of the TUI overhaul plan.

## Changes

**New components:**
- `ModalLayer` — renders all modals/pickers exactly once, regardless of app state (welcome vs chat)
- `WelcomeScreen` — ASCII banner + input area (displayed when no messages exist)
- `ChatScreen` — scrollable message list + input + side panel (displayed with messages)

**Refactored:**
- `AppContent` in `src/tui/index.tsx` reduced from 532 lines to ~230 lines of pure composition
- ~80 lines of duplicated modal JSX eliminated
- Fragile prop extraction patterns documented with explicit comments

## Before/After

**Before:** `index.tsx` contained all modal rendering duplicated in two `<Show>` branches, plus all message rendering inline.

**After:** `index.tsx` composes `<ModalLayer>` + `<Show fallback={<WelcomeScreen>}><ChatScreen></Show>` — each component owns its own rendering.

## Verification

- [x] `bun run check:types` — no errors in `src/`
- [x] `bun run build` — succeeds
- [x] Zero behavioral changes — pure refactoring

Ref: #51