### PR TITLE
feat(tui): Phase 7 — Theme auto-detection, layout shorthands, autoFocus

### DIFF
--- a/src/design/ThemeProvider.tsx
+++ b/src/design/ThemeProvider.tsx
@@ -16,7 +16,6 @@ import {
   createSignal,
   createMemo,
   createEffect,
-  onMount,
   onCleanup,
   type JSX,
 } from 'solid-js';
@@ -46,31 +45,24 @@ export function ThemeProvider(props: ThemeProviderProps) {
     props.initialTheme ?? DEFAULT_THEME_ID,
   );
 
-  // Manual override signal — when the user explicitly picks a color scheme
-  const [manualScheme, setManualScheme] = createSignal<'dark' | 'light' | null>(
-    props.colorScheme ?? null,
-  );
-
   // Detected scheme from the terminal (via renderer.themeMode / Mode 2031)
   const [detectedScheme, setDetectedScheme] = createSignal<'dark' | 'light'>(
     renderer.themeMode ?? 'dark',
   );
 
-  // Listen for terminal theme changes (auto-switches without restart)
-  onMount(() => {
-    const handler = (mode: 'dark' | 'light') => {
-      setDetectedScheme(mode);
-    };
-    renderer.on('theme_mode', handler);
-    onCleanup(() => {
-      renderer.off('theme_mode', handler);
-    });
-  });
+  // Listen for terminal theme changes (auto-switches without restart).
+  // Registered at component scope (not onMount) so no events are missed
+  // between render and the next microtask.
+  const themeHandler = (mode: 'dark' | 'light') => setDetectedScheme(mode);
+  renderer.on('theme_mode', themeHandler);
+  onCleanup(() => renderer.off('theme_mode', themeHandler));
 
-  // Effective color scheme: manual override > detected > dark fallback
+  // Effective color scheme: prop override > detected > dark fallback.
+  // props.colorScheme is read reactively — if a parent ever changes it,
+  // the theme updates automatically.
   const isDark = createMemo(() => {
-    const manual = manualScheme();
-    if (manual) return manual === 'dark';
+    const override = props.colorScheme;
+    if (override) return override === 'dark';
     return detectedScheme() === 'dark';
   });
 

--- a/src/design/ThemeProvider.tsx
+++ b/src/design/ThemeProvider.tsx
@@ -5,16 +5,28 @@
  * (e.g. `const { tokens } = useTheme()`) get a reactive proxy. Reading
  * `tokens.bgBase` inside JSX or createEffect automatically subscribes to
  * changes when the theme is switched.
+ *
+ * Dark/light detection uses the renderer's native Mode 2031 terminal query
+ * (via `renderer.themeMode`) which works on iTerm2, Ghostty, Kitty, WezTerm,
+ * Windows Terminal, and most modern emulators. Auto-switches when the terminal
+ * theme changes without requiring a restart.
  */
 
-import { createSignal, createMemo, createEffect, type JSX } from 'solid-js';
+import {
+  createSignal,
+  createMemo,
+  createEffect,
+  onMount,
+  onCleanup,
+  type JSX,
+} from 'solid-js';
 import { createStore, reconcile, produce } from 'solid-js/store';
+import { useRenderer } from '@opentui/solid';
 
 import {
   ThemeContext,
   resolveThemeVariant,
   createSyntaxStyle,
-  detectColorScheme,
   type ThemeContextValue,
 } from './theme';
 import { getTheme, DEFAULT_THEME_ID } from './themes';
@@ -23,21 +35,44 @@ export type ThemeProviderProps = {
   children: JSX.Element;
   /** Initial theme ID (defaults to "ollie") */
   initialTheme?: string;
-  /** Force dark or light mode (defaults to auto-detect) */
+  /** Force dark or light mode (overrides auto-detection). Manual selection wins. */
   colorScheme?: 'dark' | 'light';
 };
 
 export function ThemeProvider(props: ThemeProviderProps) {
+  const renderer = useRenderer();
+
   const [themeId, setThemeId] = createSignal(
     props.initialTheme ?? DEFAULT_THEME_ID,
   );
 
-  // Detect color scheme or use override (reactive if prop changes)
-  const isDark = createMemo(() =>
-    props.colorScheme
-      ? props.colorScheme === 'dark'
-      : detectColorScheme() === 'dark',
+  // Manual override signal — when the user explicitly picks a color scheme
+  const [manualScheme, setManualScheme] = createSignal<'dark' | 'light' | null>(
+    props.colorScheme ?? null,
   );
+
+  // Detected scheme from the terminal (via renderer.themeMode / Mode 2031)
+  const [detectedScheme, setDetectedScheme] = createSignal<'dark' | 'light'>(
+    renderer.themeMode ?? 'dark',
+  );
+
+  // Listen for terminal theme changes (auto-switches without restart)
+  onMount(() => {
+    const handler = (mode: 'dark' | 'light') => {
+      setDetectedScheme(mode);
+    };
+    renderer.on('theme_mode', handler);
+    onCleanup(() => {
+      renderer.off('theme_mode', handler);
+    });
+  });
+
+  // Effective color scheme: manual override > detected > dark fallback
+  const isDark = createMemo(() => {
+    const manual = manualScheme();
+    if (manual) return manual === 'dark';
+    return detectedScheme() === 'dark';
+  });
 
   // Resolve the current theme (recomputes when themeId or isDark changes)
   const resolved = createMemo(() => {

--- a/src/design/index.ts
+++ b/src/design/index.ts
@@ -36,7 +36,6 @@ export {
   createSyntaxStyle,
   ThemeContext,
   useTheme,
-  detectColorScheme,
 } from './theme';
 export type { ThemeContextValue } from './theme';
 

--- a/src/design/theme.ts
+++ b/src/design/theme.ts
@@ -191,26 +191,3 @@ export function useStyles<T>(factory: (tokens: SemanticTokens) => T): T {
   const { tokens } = useTheme();
   return factory(tokens);
 }
-
-/**
- * Detect if the terminal is in dark mode.
- * Falls back to dark mode if detection fails.
- */
-export function detectColorScheme(): 'dark' | 'light' {
-  // Check COLORFGBG environment variable (format: "fg;bg")
-  // Low bg values typically indicate dark mode
-  const colorFgBg = process.env.COLORFGBG;
-  if (colorFgBg) {
-    const parts = colorFgBg.split(';');
-    const bg = parseInt(parts[1] ?? '', 10);
-    if (!Number.isNaN(bg)) {
-      // Standard terminal colors: 0-7 are "dark", 8-15 are "light"
-      // Background < 8 typically means dark background
-      return bg < 8 ? 'dark' : 'light';
-    }
-  }
-
-  // Most modern terminals default to dark mode
-  // Default to dark as it's the most common for developer terminals
-  return 'dark';
-}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -100,6 +100,7 @@ program
 
     const renderer = await createCliRenderer({
       exitOnCtrlC: true,
+      autoFocus: true,
     });
 
     void render(

--- a/src/tui/components/chat-screen.tsx
+++ b/src/tui/components/chat-screen.tsx
@@ -101,8 +101,7 @@ export function ChatScreen(props: ChatScreenProps) {
         flexGrow={1}
         flexShrink={1}
         paddingTop={1}
-        paddingLeft={2}
-        paddingRight={2}
+        paddingX={2}
       >
         <scrollbox
           flexGrow={1}

--- a/src/tui/components/chat-screen.tsx
+++ b/src/tui/components/chat-screen.tsx
@@ -110,6 +110,7 @@ export function ChatScreen(props: ChatScreenProps) {
           stickyStart="bottom"
           scrollAcceleration={fastScrollAccel}
         >
+          {/* paddingRight only — leaves left flush for message indent, right gutter for scrollbar */}
           <box flexDirection="column" flexGrow={1} paddingRight={2}>
             <For each={props.displayMessages()}>
               {(msg) => (

--- a/src/tui/components/command-menu.tsx
+++ b/src/tui/components/command-menu.tsx
@@ -97,8 +97,7 @@ export function CommandMenu(rawProps: CommandMenuProps) {
             zIndex: 100,
             backgroundColor: tokens.bgSurface,
             flexDirection: 'column',
-            paddingLeft: 1,
-            paddingRight: 1,
+            paddingX: 1,
           }}
         >
           <text style={{ fg: tokens.textSubtle }}>No matching commands</text>
@@ -126,8 +125,7 @@ export function CommandMenu(rawProps: CommandMenuProps) {
                   <box
                     style={{
                       flexDirection: 'row',
-                      paddingLeft: 1,
-                      paddingRight: 1,
+                      paddingX: 1,
                       backgroundColor: isSelected()
                         ? tokens.selected
                         : 'transparent',

--- a/src/tui/components/compaction-summary.tsx
+++ b/src/tui/components/compaction-summary.tsx
@@ -26,7 +26,7 @@ export function CompactionSummary(props: CompactionSummaryProps) {
           borderColor: tokens.borderMuted,
         }}
       />
-      <box marginLeft={2} marginRight={2} marginTop={1} marginBottom={1}>
+      <box marginX={2} marginY={1}>
         <text style={{ fg: tokens.textSubtle }}>
           <strong>Compaction</strong> ({props.compactedCount} messages
           summarized)

--- a/src/tui/components/error-message.tsx
+++ b/src/tui/components/error-message.tsx
@@ -24,7 +24,7 @@ export function ErrorMessage(props: ErrorMessageProps) {
   const label = () => ERROR_LABELS[props.errorType] ?? props.errorType;
 
   return (
-    <box flexDirection="column" marginTop={1} marginBottom={1}>
+    <box flexDirection="column" marginY={1}>
       <box
         style={{
           border: ['left'],

--- a/src/tui/components/file-picker.tsx
+++ b/src/tui/components/file-picker.tsx
@@ -107,8 +107,7 @@ export function FilePicker(rawProps: FilePickerProps) {
             zIndex: 100,
             backgroundColor: tokens.bgSurface,
             flexDirection: 'column',
-            paddingLeft: 1,
-            paddingRight: 1,
+            paddingX: 1,
           }}
         >
           <text style={{ fg: tokens.textSubtle }}>No matching files</text>
@@ -140,8 +139,7 @@ export function FilePicker(rawProps: FilePickerProps) {
                   <box
                     style={{
                       flexDirection: 'row',
-                      paddingLeft: 1,
-                      paddingRight: 1,
+                      paddingX: 1,
                       backgroundColor: isSelected()
                         ? tokens.selected
                         : 'transparent',

--- a/src/tui/components/input-box.tsx
+++ b/src/tui/components/input-box.tsx
@@ -107,8 +107,7 @@ export function InputBox(props: InputBoxProps) {
         borderColor: tokens.borderAccent,
         backgroundColor: tokens.bgInput,
         padding: 1,
-        paddingLeft: 2,
-        paddingRight: 2,
+        paddingX: 2,
         ...(props.centered && { marginTop: 2, width: 60 }),
       }}
     >

--- a/src/tui/components/modal.tsx
+++ b/src/tui/components/modal.tsx
@@ -63,10 +63,8 @@ export function Modal(rawProps: ModalProps) {
           maxHeight: Math.floor(dimensions().height / 2),
           backgroundColor: tokens.bgSurface,
           flexDirection: 'column',
-          paddingTop: 1,
-          paddingBottom: 1,
-          paddingLeft: 2,
-          paddingRight: 2,
+          paddingY: 1,
+          paddingX: 2,
           zIndex: 101,
         }}
       >

--- a/src/tui/components/side-panel.tsx
+++ b/src/tui/components/side-panel.tsx
@@ -247,10 +247,8 @@ export function SidePanel(rawProps: SidePanelProps) {
       style={{
         backgroundColor: tokens.bgSurface,
         flexDirection: 'column',
-        paddingTop: 1,
-        paddingBottom: 1,
-        paddingLeft: 2,
-        paddingRight: 2,
+        paddingY: 1,
+        paddingX: 2,
       }}
       width={props.width}
     >

--- a/src/tui/components/toast-notification.tsx
+++ b/src/tui/components/toast-notification.tsx
@@ -38,8 +38,7 @@ export function ToastNotification(props: ToastNotificationProps) {
         borderStyle: 'single',
         borderColor: tokens.success,
         padding: 1,
-        paddingLeft: 2,
-        paddingRight: 2,
+        paddingX: 2,
         zIndex: 100,
       }}
     >


### PR DESCRIPTION
## Summary

Adopts native terminal theme detection, modernizes layout props with axis shorthands, and enables autoFocus on the renderer.

## Changes

### Theme Auto-Detection
- **Removed** `detectColorScheme()` which only checked the `COLORFGBG` env var (broken on most modern terminals)
- **Added** native `renderer.themeMode` (Mode 2031 terminal query) for initial dark/light detection
- **Added** live `theme_mode` event listener — theme auto-switches when terminal appearance changes (no restart required)
- Works on: iTerm2, Ghostty, Kitty, WezTerm, Windows Terminal
- Manual theme selection (`/theme`) still overrides auto-detection

### Layout Shorthands
Replaced 13 instances of explicit `paddingLeft`/`paddingRight` and `marginTop`/`marginBottom` pairs with `paddingX`/`paddingY`/`marginX`/`marginY` shorthands across 9 components:
- modal, side-panel, chat-screen, input-box, command-menu, file-picker, toast-notification, compaction-summary, error-message

### Renderer
- Added `autoFocus: true` to `createCliRenderer` options

## Verification
- [x] `bun run check:types` — no errors in `src/`
- [x] `bun run build` — succeeds
- [x] Layout spacing unchanged (shorthands are semantically identical)

Ref: #51