### PR TITLE
feat(tui): Phase 3 — streaming markdown rendering

### DIFF
--- a/src/tui/components/assistant-message.tsx
+++ b/src/tui/components/assistant-message.tsx
@@ -17,12 +17,10 @@ export function AssistantMessage(props: AssistantMessageProps) {
 
   return (
     <box flexDirection="column" marginLeft={2}>
-      <code
-        selectable={true}
+      <markdown
         content={props.content}
-        filetype="markdown"
         syntaxStyle={markdownStyle()}
-        drawUnstyledText={true}
+        conceal={true}
       />
     </box>
   );

--- a/src/tui/components/chat-screen.tsx
+++ b/src/tui/components/chat-screen.tsx
@@ -4,9 +4,10 @@
  */
 
 import type { Accessor } from 'solid-js';
-import { For, Show } from 'solid-js';
+import { createMemo, For, Show } from 'solid-js';
 import type { McpStatusMap } from '../../agent/mcp/types';
 import { useTheme } from '../../design';
+import { createMarkdownSyntaxStyle } from '../utils';
 import type {
   AgentMode,
   CompactionSummaryDisplayMessage,
@@ -88,6 +89,7 @@ export interface ChatScreenProps {
 
 export function ChatScreen(props: ChatScreenProps) {
   const { tokens } = useTheme();
+  const markdownStyle = createMemo(() => createMarkdownSyntaxStyle(tokens));
 
   return (
     <box
@@ -173,8 +175,13 @@ export function ChatScreen(props: ChatScreenProps) {
             </For>
 
             <Show when={props.streamingContent()}>
-              <box>
-                <text>{props.streamingContent()}</text>
+              <box marginLeft={2}>
+                <markdown
+                  content={props.streamingContent()!}
+                  syntaxStyle={markdownStyle()}
+                  streaming={true}
+                  conceal={true}
+                />
               </box>
             </Show>
           </box>

--- a/src/tui/components/compaction-summary.tsx
+++ b/src/tui/components/compaction-summary.tsx
@@ -33,12 +33,10 @@ export function CompactionSummary(props: CompactionSummaryProps) {
         </text>
       </box>
       <box marginLeft={2}>
-        <code
-          selectable={true}
+        <markdown
           content={props.content}
-          filetype="markdown"
           syntaxStyle={markdownStyle()}
-          drawUnstyledText={true}
+          conceal={true}
         />
       </box>
       <box


### PR DESCRIPTION
## Phase 3: Streaming Markdown Rendering

Replaces raw `<text>` streaming and `<code filetype="markdown">` with the purpose-built `<markdown>` element from OpenTUI.

### Changes

**chat-screen.tsx**
- Streaming content now uses `<markdown streaming={true}>` instead of `<text>{content}</text>`
- Added `syntaxStyle` and `conceal` props for proper markdown formatting during token streaming
- Added `marginLeft={2}` to match finalized message indent (fixes visual snap on completion)

**assistant-message.tsx**
- Replaced `<code filetype="markdown">` with `<markdown conceal={true}>`
- Removed `drawUnstyledText` (code-specific prop)

**compaction-summary.tsx**
- Same migration as assistant-message.tsx

### Trade-offs

- `selectable={true}` was dropped — `<markdown>` does not support this prop (only `<code>` did). Text selection in finalized messages is lost until OpenTUI adds selectability to the markdown element.

### Acceptance criteria from plan
- [x] Streaming responses render with markdown formatting in real-time
- [x] `streaming={true}` used during active streaming
- [x] Finalized messages use `<markdown>` instead of `<code filetype="markdown">`
- [x] `syntaxStyle` from current theme passed correctly
- [x] Code blocks within markdown have syntax highlighting
- [x] Types pass (`bun run check:types` — no src/ errors)
- [x] Lint clean (`bun run lint` — no new warnings)

Closes phase 3 of #51.