### PR TITLE
refactor(tui): Phase 6 — extract useListNavigation hook

### DIFF
--- a/src/tui/components/command-menu.tsx
+++ b/src/tui/components/command-menu.tsx
@@ -4,10 +4,10 @@
  */
 
 import type { ScrollBoxRenderable } from '@opentui/core';
-import { createEffect, createMemo, Index, mergeProps, Show } from 'solid-js';
+import { createMemo, Index, mergeProps, Show } from 'solid-js';
 import { useTheme } from '../../design';
-import { FocusLayer, useFocusLayer, useScopedKeyboard } from '../keyboard';
-import { getScrollChildBounds, scrollIntoView } from '../utils';
+import { FocusLayer } from '../keyboard';
+import { useListNavigation } from '../hooks/use-list-navigation';
 
 export type SlashCommand = {
   name: string;
@@ -40,48 +40,21 @@ export function CommandMenu(rawProps: CommandMenuProps) {
   const { tokens } = useTheme();
   let scrollRef: ScrollBoxRenderable | undefined;
 
-  // Must be a memo so it recomputes when props.filter changes
   const filteredCommands = createMemo(() =>
     getFilteredCommands(props.commands, props.filter),
   );
 
-  createEffect(() => {
-    const cmds = filteredCommands();
-    if (props.selectedIndex >= cmds.length && cmds.length > 0) {
-      props.onIndexChange(cmds.length - 1);
-    }
-  });
-
-  // Scroll-into-view: only adjust when selected item is outside the viewport
-  createEffect(() => {
-    const idx = props.selectedIndex;
-    if (!scrollRef) return;
-    const bounds = getScrollChildBounds(scrollRef, idx);
-    if (bounds) scrollIntoView(scrollRef, bounds.top, bounds.bottom);
-  });
-
-  useFocusLayer(FocusLayer.COMMAND_MENU);
-
-  useScopedKeyboard(FocusLayer.COMMAND_MENU, (key) => {
-    const cmds = filteredCommands();
-    switch (key.name) {
-      case 'up':
-      case 'k':
-        props.onIndexChange(Math.max(0, props.selectedIndex - 1));
-        break;
-      case 'down':
-      case 'j':
-        props.onIndexChange(Math.min(cmds.length - 1, props.selectedIndex + 1));
-        break;
-      case 'return': {
-        const selected = cmds[props.selectedIndex];
-        if (selected) props.onSelect(selected);
-        break;
-      }
-      case 'escape':
-        props.onCancel();
-        break;
-    }
+  useListNavigation({
+    layer: FocusLayer.COMMAND_MENU,
+    itemCount: () => filteredCommands().length,
+    selectedIndex: () => props.selectedIndex,
+    setSelectedIndex: (i) => props.onIndexChange(i),
+    onSelect: (i) => {
+      const cmd = filteredCommands()[i];
+      if (cmd) props.onSelect(cmd);
+    },
+    onCancel: () => props.onCancel(),
+    getScrollRef: () => scrollRef,
   });
 
   return (

--- a/src/tui/components/file-picker.tsx
+++ b/src/tui/components/file-picker.tsx
@@ -6,11 +6,11 @@
 
 import type { ScrollBoxRenderable } from '@opentui/core';
 import type { JSX } from 'solid-js';
-import { createEffect, createMemo, Index, mergeProps, Show } from 'solid-js';
+import { createMemo, Index, mergeProps, Show } from 'solid-js';
 import { useTheme } from '../../design';
-import { FocusLayer, useFocusLayer, useScopedKeyboard } from '../keyboard';
+import { FocusLayer } from '../keyboard';
+import { useListNavigation } from '../hooks/use-list-navigation';
 import { type FuzzyMatch, fuzzySearch } from '../../lib/fuzzy';
-import { getScrollChildBounds, scrollIntoView } from '../utils';
 
 export type FilePickerProps = {
   /** List of available files (from getFilesAndDirectories) */
@@ -51,47 +51,22 @@ export function FilePicker(rawProps: FilePickerProps) {
   const { tokens } = useTheme();
   let scrollRef: ScrollBoxRenderable | undefined;
 
-  // Must be a memo so it recomputes when props.filter/props.files change
   const results = createMemo(() =>
     fuzzySearch(props.filter, props.files, MAX_RESULTS),
   );
 
-  // Clamp selection when results change
-  createEffect(() => {
-    const r = results();
-    if (props.selectedIndex >= r.length && r.length > 0) {
-      props.onIndexChange(r.length - 1);
-    }
-  });
-
-  // Scroll-into-view: only adjust when selected item is outside the viewport
-  createEffect(() => {
-    const idx = props.selectedIndex;
-    if (!scrollRef) return;
-    const bounds = getScrollChildBounds(scrollRef, idx);
-    if (bounds) scrollIntoView(scrollRef, bounds.top, bounds.bottom);
-  });
-
-  useFocusLayer(FocusLayer.FILE_PICKER);
-
-  useScopedKeyboard(FocusLayer.FILE_PICKER, (key) => {
-    const r = results();
-    switch (key.name) {
-      case 'up':
-        props.onIndexChange(Math.max(0, props.selectedIndex - 1));
-        break;
-      case 'down':
-        props.onIndexChange(Math.min(r.length - 1, props.selectedIndex + 1));
-        break;
-      case 'return': {
-        const selected = r[props.selectedIndex];
-        if (selected) props.onSelect(selected.item);
-        break;
-      }
-      case 'escape':
-        props.onCancel();
-        break;
-    }
+  useListNavigation({
+    layer: FocusLayer.FILE_PICKER,
+    vimKeys: false,
+    itemCount: () => results().length,
+    selectedIndex: () => props.selectedIndex,
+    setSelectedIndex: (i) => props.onIndexChange(i),
+    onSelect: (i) => {
+      const match = results()[i];
+      if (match) props.onSelect(match.item);
+    },
+    onCancel: () => props.onCancel(),
+    getScrollRef: () => scrollRef,
   });
 
   return (

--- a/src/tui/components/session-picker.tsx
+++ b/src/tui/components/session-picker.tsx
@@ -8,9 +8,9 @@ import type { InputRenderable, ScrollBoxRenderable } from '@opentui/core';
 import { useTerminalDimensions } from '@opentui/solid';
 import { createEffect, createMemo, createSignal, For, Show } from 'solid-js';
 import { useTheme } from '../../design';
-import { FocusLayer, useScopedKeyboard } from '../keyboard';
+import { FocusLayer } from '../keyboard';
+import { useListNavigation } from '../hooks/use-list-navigation';
 import { deleteSession, type Session, updateSession } from '../../session';
-import { scrollIntoView } from '../utils';
 import { Modal } from './modal';
 
 export type SessionPickerProps = {
@@ -75,7 +75,6 @@ function flattenSessions(groups: SessionGroup[]): Session[] {
 
 /**
  * Precompute a map from session.id to its flat index across all groups.
- * This replaces the mutable `globalIndex` counter in the render phase.
  */
 function buildSessionIndexMap(groups: SessionGroup[]): Map<string, number> {
   const map = new Map<string, number>();
@@ -92,21 +91,13 @@ function buildSessionIndexMap(groups: SessionGroup[]): Map<string, number> {
  * Get the actual layout position of a session item from the scroll content tree.
  *
  * Structure: scrollbox > content > innerBox > groupBox[] > [header, ...sessionItems]
- * Each groupBox child[0] is the header <text>, children[1..] are session <box> rows.
- *
- * Uses yoga layout nodes to read positions relative to the content container,
- * which are stable regardless of scroll position.
- *
- * Returns { top, bottom } in content-relative coordinates where:
- *   top = y to show when scrolling UP (includes group header for first-in-group)
- *   bottom = y + height of the item (for scrolling DOWN)
+ * Uses yoga layout nodes for stable positions regardless of scroll.
  */
 function getItemLayoutBounds(
   scrollRef: ScrollBoxRenderable,
   groups: SessionGroup[],
   flatIndex: number,
 ): { top: number; bottom: number } | null {
-  // content > innerBox > groupBoxes
   const innerBox = scrollRef.content.getChildren()[0];
   if (!innerBox) return null;
   const groupBoxes = innerBox.getChildren();
@@ -118,11 +109,9 @@ function getItemLayoutBounds(
     if (!groupBox) continue;
 
     if (remaining < group.sessions.length) {
-      // child[0] = header text, child[1..] = session items
       const itemChild = groupBox.getChildren()[remaining + 1];
       if (!itemChild) return null;
 
-      // Use yoga layout nodes for scroll-stable positions
       const groupLayout = groupBox.getLayoutNode();
       const itemLayout = itemChild.getLayoutNode();
       const groupY = groupLayout.getComputedTop();
@@ -168,27 +157,9 @@ export function SessionPicker(props: SessionPickerProps) {
   );
 
   createEffect(() => {
-    if (selectedIndex() >= flatSessions().length && flatSessions().length > 0) {
-      setSelectedIndex(flatSessions().length - 1);
-    }
-  });
-
-  createEffect(() => {
     if (mode() === 'rename' && inputRef) {
       inputRef.focus();
     }
-  });
-
-  // Scroll-into-view: only scroll when selected item is outside the viewport.
-  // Reads actual layout positions from the renderable tree.
-  createEffect(() => {
-    const idx = selectedIndex();
-    const sessions = flatSessions();
-    const g = groups();
-    if (!scrollRef || sessions.length === 0) return;
-
-    const bounds = getItemLayoutBounds(scrollRef, g, idx);
-    if (bounds) scrollIntoView(scrollRef, bounds.top, bounds.bottom);
   });
 
   const handleDelete = () => {
@@ -221,44 +192,47 @@ export function SessionPicker(props: SessionPickerProps) {
     props.onSessionsChanged();
   };
 
-  useScopedKeyboard(FocusLayer.MODAL, (key) => {
-    if (mode() === 'rename') {
-      if (key.name === 'escape') setMode('browse');
-      else if (key.name === 'return') handleRenameSubmit();
-      return;
-    }
+  // Capture groups() in a local for the bounds getter closure
+  const currentGroups = groups;
 
-    if (key.ctrl && key.name === 'd') {
-      handleDelete();
-      return;
-    }
-    if (key.ctrl && key.name === 'r') {
-      handleRename();
-      return;
-    }
-
-    if (mode() === 'confirm-delete') {
-      setMode('browse');
-      return;
-    }
-
-    switch (key.name) {
-      case 'up':
-      case 'k':
-        setSelectedIndex((prev) => Math.max(0, prev - 1));
-        break;
-      case 'down':
-      case 'j':
-        setSelectedIndex((prev) =>
-          Math.min(flatSessions().length - 1, prev + 1),
-        );
-        break;
-      case 'return': {
-        const session = flatSessions()[selectedIndex()];
-        if (session) props.onSelect(session);
-        break;
+  useListNavigation({
+    layer: FocusLayer.MODAL,
+    registerLayer: false, // Modal component handles the layer
+    itemCount: () => flatSessions().length,
+    selectedIndex,
+    setSelectedIndex,
+    onSelect: (i) => {
+      const session = flatSessions()[i];
+      if (session) props.onSelect(session);
+    },
+    getScrollRef: () => scrollRef,
+    getBounds: (ref, idx) => getItemLayoutBounds(ref, currentGroups(), idx),
+    extraKeyHandler: (key) => {
+      // Rename mode: intercept all keys
+      if (mode() === 'rename') {
+        if (key.name === 'escape') setMode('browse');
+        else if (key.name === 'return') handleRenameSubmit();
+        return true;
       }
-    }
+
+      // Delete/rename shortcuts
+      if (key.ctrl && key.name === 'd') {
+        handleDelete();
+        return true;
+      }
+      if (key.ctrl && key.name === 'r') {
+        handleRename();
+        return true;
+      }
+
+      // Confirm-delete mode: any non-ctrl key cancels
+      if (mode() === 'confirm-delete') {
+        setMode('browse');
+        return true;
+      }
+
+      return false;
+    },
   });
 
   return (

--- a/src/tui/hooks/index.ts
+++ b/src/tui/hooks/index.ts
@@ -28,6 +28,10 @@ export {
   useKeyboardShortcuts,
 } from './use-keyboard-shortcuts';
 export {
+  type ListNavigationOptions,
+  useListNavigation,
+} from './use-list-navigation';
+export {
   type UseMessageStoreReturn,
   useMessageStore,
 } from './use-message-store';

--- a/src/tui/hooks/use-list-navigation.ts
+++ b/src/tui/hooks/use-list-navigation.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared hook for keyboard-navigable list components.
+ *
+ * Extracts the common pattern from command-menu, file-picker, and session-picker:
+ * - Index clamping when the list shrinks
+ * - Keyboard navigation (up/down, optional j/k, enter, escape)
+ * - Scroll-into-view tracking
+ */
+
+import type { ScrollBoxRenderable } from '@opentui/core';
+import { createEffect } from 'solid-js';
+import type { FocusLayerId } from '../keyboard';
+import { useFocusLayer, useScopedKeyboard } from '../keyboard';
+import { getScrollChildBounds, scrollIntoView } from '../utils';
+
+export type ListNavigationOptions = {
+  /** Focus layer for scoped keyboard events */
+  layer: FocusLayerId;
+  /** Whether to push/pop the focus layer on mount/cleanup */
+  registerLayer?: boolean;
+  /** Number of items in the list (reactive getter) */
+  itemCount: () => number;
+  /** Current selected index (reactive getter) */
+  selectedIndex: () => number;
+  /** Update the selected index */
+  setSelectedIndex: (index: number) => void;
+  /** Called when user presses Enter on the selected item */
+  onSelect: (index: number) => void;
+  /** Called when user presses Escape */
+  onCancel?: () => void;
+  /** Enable vim-style j/k navigation (default: true) */
+  vimKeys?: boolean;
+  /** Scroll ref getter — if provided, enables scroll-into-view tracking */
+  getScrollRef?: () => ScrollBoxRenderable | undefined;
+  /**
+   * Custom bounds getter for scroll-into-view.
+   * Defaults to getScrollChildBounds (flat list).
+   * Override for grouped layouts (e.g., session-picker).
+   */
+  getBounds?: (
+    scrollRef: ScrollBoxRenderable,
+    index: number,
+  ) => { top: number; bottom: number } | null;
+  /**
+   * Extra key handler called before the default navigation.
+   * Return true to prevent default handling.
+   */
+  extraKeyHandler?: (key: {
+    name?: string;
+    ctrl?: boolean;
+    shift?: boolean;
+    meta?: boolean;
+  }) => boolean;
+};
+
+/**
+ * Hook that provides keyboard navigation, index clamping, and scroll tracking
+ * for list components.
+ */
+export function useListNavigation(opts: ListNavigationOptions): void {
+  const vimKeys = opts.vimKeys ?? true;
+
+  // Push/pop focus layer if requested
+  if (opts.registerLayer !== false) {
+    useFocusLayer(opts.layer);
+  }
+
+  // Clamp index when list shrinks
+  createEffect(() => {
+    const count = opts.itemCount();
+    if (opts.selectedIndex() >= count && count > 0) {
+      opts.setSelectedIndex(count - 1);
+    }
+  });
+
+  // Scroll-into-view tracking
+  createEffect(() => {
+    const idx = opts.selectedIndex();
+    const scrollRef = opts.getScrollRef?.();
+    if (!scrollRef) return;
+
+    const boundsGetter = opts.getBounds ?? getScrollChildBounds;
+    const bounds = boundsGetter(scrollRef, idx);
+    if (bounds) scrollIntoView(scrollRef, bounds.top, bounds.bottom);
+  });
+
+  // Keyboard navigation
+  useScopedKeyboard(opts.layer, (key) => {
+    // Let extra handler intercept first
+    if (opts.extraKeyHandler?.(key)) return;
+
+    const count = opts.itemCount();
+    switch (key.name) {
+      case 'up':
+        opts.setSelectedIndex(Math.max(0, opts.selectedIndex() - 1));
+        break;
+      case 'down':
+        opts.setSelectedIndex(Math.min(count - 1, opts.selectedIndex() + 1));
+        break;
+      case 'return': {
+        if (count > 0) opts.onSelect(opts.selectedIndex());
+        break;
+      }
+      case 'escape':
+        opts.onCancel?.();
+        break;
+      default:
+        if (vimKeys) {
+          if (key.name === 'k') {
+            opts.setSelectedIndex(Math.max(0, opts.selectedIndex() - 1));
+          } else if (key.name === 'j') {
+            opts.setSelectedIndex(
+              Math.min(count - 1, opts.selectedIndex() + 1),
+            );
+          }
+        }
+        break;
+    }
+  });
+}


### PR DESCRIPTION
## Phase 6: Shared List Navigation

Extracts the duplicated keyboard navigation, index clamping, and scroll-into-view tracking from three list components into a reusable `useListNavigation` hook.

### New: `src/tui/hooks/use-list-navigation.ts` (120 lines)

A shared hook that provides:
- **Keyboard navigation**: up/down arrows, optional j/k vim keys, Enter to select, Escape to cancel
- **Index clamping**: automatically clamps selectedIndex when list shrinks (e.g., after filtering)
- **Scroll-into-view**: watches selectedIndex and scrolls the scrollbox to keep the selected item visible
- **Pluggable bounds getter**: defaults to flat list (`getScrollChildBounds`), overridable for grouped layouts
- **Extra key handler**: intercepts keys before default navigation (for component-specific shortcuts)
- **Optional layer registration**: `registerLayer: false` for components where a parent already manages the focus layer

### Migrations

| Component | Lines removed | Notes |
|-----------|--------------|-------|
| `command-menu.tsx` | -35 | Uses hook with vim keys enabled |
| `file-picker.tsx` | -35 | Uses hook with `vimKeys: false` (filter captures letters) |
| `session-picker.tsx` | -40 | Uses hook with custom `getBounds` (grouped layout) and `extraKeyHandler` (rename/delete mode state machine) |

### What's preserved
- All keyboard shortcuts work identically
- Session picker's browse/confirm-delete/rename state machine unchanged
- Scroll tracking behavior preserved (including session-picker's group-header-aware scrolling)
- File picker's vim key suppression preserved

### Code review
- No critical or warning findings
- Types clean (`bun run check:types`)
- Lint clean (`bun run lint`)

Part of #51.