### PR TITLE
perf(tui): Phase 9 — performance polish

### DIFF
--- a/src/tui/components/modal-layer.tsx
+++ b/src/tui/components/modal-layer.tsx
@@ -4,7 +4,7 @@
  */
 
 import type { Accessor } from 'solid-js';
-import { Show } from 'solid-js';
+import { createMemo, Show } from 'solid-js';
 import type { McpStatusMap } from '../../agent/mcp/types';
 import type { McpManager } from '../../agent/mcp/manager';
 import type { ConfigLayer } from '../../config/merge';
@@ -59,6 +59,13 @@ export interface ModalLayerProps {
 }
 
 export function ModalLayer(props: ModalLayerProps) {
+  // Memoize session list to avoid re-querying SQLite on unrelated signal changes
+  const sessions = createMemo(() =>
+    props.showSessionPicker()
+      ? listSessions({ limit: props.sessionListLimit })
+      : [],
+  );
+
   return (
     <>
       <Show when={props.showContextStats() && props.contextStats()}>
@@ -94,7 +101,7 @@ export function ModalLayer(props: ModalLayerProps) {
 
       <Show when={props.showSessionPicker()}>
         <SessionPicker
-          sessions={listSessions({ limit: props.sessionListLimit })}
+          sessions={sessions()}
           projectPath={props.projectPath}
           onSelect={props.onSessionSelect}
           onCancel={props.onSessionPickerCancel}

--- a/src/tui/components/side-panel.tsx
+++ b/src/tui/components/side-panel.tsx
@@ -3,7 +3,14 @@
  * Always visible on the right side of the chat interface.
  */
 
-import { createMemo, createSignal, For, mergeProps, Show } from 'solid-js';
+import {
+  createMemo,
+  createSignal,
+  For,
+  Index,
+  mergeProps,
+  Show,
+} from 'solid-js';
 import type { McpStatusMap } from '../../agent/mcp/types';
 import type { SemanticTokens } from '../../design';
 import { useTheme } from '../../design';
@@ -218,22 +225,28 @@ function McpSection(props: {
         <text style={{ fg: props.tokens.textMuted }}>connecting...</text>
       </Show>
 
-      <For each={entries()}>
-        {([name, info]) => {
+      {/* Index instead of For: entries() creates new tuple arrays on each
+          evaluation, so referential identity is unstable. Index tracks by
+          position which is correct for a Map-derived list. */}
+      <Index each={entries()}>
+        {(entry) => {
+          const name = () => entry()[0];
+          const info = () => entry()[1];
           const icon = () =>
-            MCP_STATUS_ICONS[info.status] ?? MCP_STATUS_ICONS.disconnected;
-          const color = () => mcpStatusColor(info.status, props.tokens);
-          const detail = () => getMcpStatusDetail(info.status, info.toolCount);
+            MCP_STATUS_ICONS[info().status] ?? MCP_STATUS_ICONS.disconnected;
+          const color = () => mcpStatusColor(info().status, props.tokens);
+          const detail = () =>
+            getMcpStatusDetail(info().status, info().toolCount);
 
           return (
             <box flexDirection="row">
               <text style={{ fg: color() }}>{icon()} </text>
-              <text style={{ fg: props.tokens.textMuted }}>{name} </text>
+              <text style={{ fg: props.tokens.textMuted }}>{name()} </text>
               <text style={{ fg: color() }}>{detail()}</text>
             </box>
           );
         }}
-      </For>
+      </Index>
     </box>
   );
 }

--- a/src/tui/hooks/use-list-navigation.ts
+++ b/src/tui/hooks/use-list-navigation.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ScrollBoxRenderable } from '@opentui/core';
-import { createEffect } from 'solid-js';
+import { createEffect, untrack } from 'solid-js';
 import type { FocusLayerId } from '../keyboard';
 import { useFocusLayer, useScopedKeyboard } from '../keyboard';
 import { getScrollChildBounds, scrollIntoView } from '../utils';
@@ -65,10 +65,11 @@ export function useListNavigation(opts: ListNavigationOptions): void {
     useFocusLayer(opts.layer);
   }
 
-  // Clamp index when list shrinks
+  // Clamp index when list shrinks — only track itemCount, not selectedIndex
   createEffect(() => {
     const count = opts.itemCount();
-    if (opts.selectedIndex() >= count && count > 0) {
+    const idx = untrack(() => opts.selectedIndex());
+    if (idx >= count && count > 0) {
       opts.setSelectedIndex(count - 1);
     }
   });


### PR DESCRIPTION
## Phase 9: Performance Polish

Performance audit of all TUI components, fixing three actionable findings.

### Fixes

**1. side-panel.tsx — Unstable `<For>` references for MCP entries**

`Array.from(map.entries())` creates new tuple arrays on every evaluation, causing `<For>` to tear down and rebuild all items even when nothing changed. Replaced with `<Index>` which tracks by position — correct for a Map-derived list.

**2. modal-layer.tsx — Inline `listSessions()` re-querying SQLite**

`listSessions({ limit: ... })` was called inline in JSX inside a `<Show>` block. Any signal change within that block would re-execute the SQLite query. Now wrapped in `createMemo` gated by `showSessionPicker()` — only queries when the picker is open.

**3. use-list-navigation.ts — Clamp effect firing on every keystroke**

The index-clamping effect subscribed to both `itemCount()` and `selectedIndex()`. It should only re-run when `itemCount` changes (list shrinks). Added `untrack()` on `selectedIndex` read — eliminates unnecessary effect runs on every navigation keystroke across all three list consumers (command-menu, file-picker, session-picker).

### Audit summary

The full audit found no Critical issues. The codebase is well-structured:
- `<For>` loops use stable references (memos) throughout
- `createMemo` is used for all expensive derivations
- Session picker's nested `<For>` with per-item memos is correct
- No signal leaks detected

Part of #51.