### PR TITLE
feat(tui): wire AgentRegistry into TUI layer (#117)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,11 @@ import { createCliRenderer } from '@opentui/core';
 import { render } from '@opentui/solid';
 import { Command } from 'commander';
 import { setDebugEnabled } from './agent/logger';
-import { buildCliOverrides, loadMergedConfig } from './config';
+import {
+  buildCliOverrides,
+  extractAgentRegistry,
+  loadMergedConfig,
+} from './config';
 import { initializeTreeSitterParsers } from './lib/tree-sitter';
 import {
   closeDatabase,
@@ -95,6 +99,15 @@ program
       }
     }
 
+    // Build agent registry (async — loads agent files from disk)
+    const { registry: agentRegistry, warnings: agentWarnings } =
+      await extractAgentRegistry(config, projectPath);
+
+    // Log agent warnings to stderr (mirroring config warnings)
+    for (const warning of agentWarnings) {
+      console.error(`[agent] ${warning.path}: ${warning.message}`);
+    }
+
     // Initialize tree-sitter client for syntax highlighting
     const treeSitterClient = await initializeTreeSitterParsers(!!tsworkerDebug);
 
@@ -109,6 +122,8 @@ program
           config={config}
           configLayers={configLayers}
           configWarnings={warnings}
+          agentRegistry={agentRegistry}
+          agentWarnings={agentWarnings}
           projectPath={projectPath}
           initialSessionId={initialSessionId}
         />

--- a/src/tui/hooks/use-agent-submit.ts
+++ b/src/tui/hooks/use-agent-submit.ts
@@ -25,6 +25,7 @@ import {
   extractSafetyConfig,
   extractToolsConfig,
 } from '../../config/resolve';
+import type { AgentRegistry } from '../../agent/agents/registry';
 import type { McpToolInfo } from '../../agent/mcp/types';
 import type { ResolvedConfig } from '../../config/schema';
 import { checkMidLoopBuffering, processOMStep } from '../../memory/om';
@@ -74,6 +75,8 @@ export type UseAgentSubmitProps = {
   setContextInfo?: (info: string | null) => void;
   /** MCP tool metadata for permissions and mode filtering (signal accessor for reactivity) */
   mcpTools?: () => McpToolInfo[];
+  /** Agent registry for subagent delegation via task tool */
+  agentRegistry: AgentRegistry;
 };
 
 export type UseAgentSubmitReturn = {
@@ -243,6 +246,7 @@ export function useAgentSubmit(
       configInstructions: props.config.instructions,
       temperature: props.config.temperature,
       mcpTools: props.mcpTools?.(),
+      agentRegistry: props.agentRegistry,
       observationBlock: omObservationBlock,
       continuationHint: omContinuationHint,
       onIterationComplete: (msgs, tokenInfo) => {

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -5,7 +5,7 @@
 
 import type { TextareaRenderable } from '@opentui/core';
 import { onBlur, onFocus, useRenderer } from '@opentui/solid';
-import { createMemo, createSignal, Show } from 'solid-js';
+import { createMemo, createSignal, onMount, Show } from 'solid-js';
 import { extractTuiConfig } from '../config/resolve';
 import { ThemeProvider } from '../design';
 import { ChatScreen, ModalLayer, WelcomeScreen } from './components';
@@ -42,6 +42,8 @@ export function App(props: AppProps) {
         config={props.config}
         configLayers={props.configLayers}
         configWarnings={props.configWarnings}
+        agentRegistry={props.agentRegistry}
+        agentWarnings={props.agentWarnings}
         projectPath={props.projectPath}
         initialSessionId={props.initialSessionId}
       />
@@ -53,6 +55,7 @@ function AppContent(props: AppProps) {
   // Static: set once at mount, never changes (config is resolved before render)
   const configLayers = props.configLayers ?? [];
   const configWarnings = props.configWarnings ?? [];
+  const agentWarnings = props.agentWarnings ?? [];
   const model = props.config.model;
 
   // Power-saving: reduce frame rate when terminal loses focus
@@ -112,6 +115,7 @@ function AppContent(props: AppProps) {
     updateRealTokenCounts: context.updateRealTokenCounts,
     setContextInfo: context.setContextInfo,
     mcpTools: mcp.mcpTools,
+    agentRegistry: props.agentRegistry,
   });
 
   // Status getter for InputBox
@@ -156,6 +160,16 @@ function AppContent(props: AppProps) {
     currentSession: session.currentSession,
     onClipboardNotify: (message: string) => setToast(message),
     tuiConfig: tuiConfig(),
+  });
+
+  // Surface agent loader warnings as toasts on startup
+  onMount(() => {
+    if (agentWarnings.length > 0) {
+      const message = agentWarnings
+        .map((w) => `${w.path}: ${w.message}`)
+        .join('\n');
+      setToast(`Agent warnings:\n${message}`);
+    }
   });
 
   // Derived: is input disabled on welcome screen

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -10,6 +10,8 @@ import type {
   ConfirmationRequest,
   ConfirmationResponse,
 } from '../agent/safety/types';
+import type { AgentRegistry } from '../agent/agents/registry';
+import type { LoadWarning } from '../agent/agents/loader';
 import type { ConfigLayer } from '../config/merge';
 import type { ResolvedConfig } from '../config/schema';
 import type { ContextStats } from '../lib/tokenizer';
@@ -115,6 +117,10 @@ export type AppProps = {
   configLayers?: ConfigLayer[];
   /** Config warnings from merge (for /config command) */
   configWarnings?: string[];
+  /** Agent registry for subagent delegation */
+  agentRegistry: AgentRegistry;
+  /** Warnings from agent loader (invalid frontmatter, schema errors, etc.) */
+  agentWarnings?: LoadWarning[];
   projectPath: string;
   initialSessionId?: string;
 };
@@ -134,7 +140,9 @@ export type StatusRef = Status;
 
 // Re-export commonly used types for convenience
 export type {
+  AgentRegistry,
   ConfigLayer,
+  LoadWarning,
   Session,
   Todo,
   ContextStats,


### PR DESCRIPTION
## Summary

Workstream 1 (Foundation) for #117 — wires the `AgentRegistry` into the TUI layer so the task tool can actually delegate to subagents.

### Problem

`AgentRegistry` was constructed in the config layer but never passed to the TUI. When `runAgent()` was called from `useAgentSubmit`, no registry was provided, meaning the task tool would fail with "requires agentRegistry in context" whenever the LLM attempted subagent delegation.

Agent loader warnings (`BuildRegistryResult.warnings`) were also silently dropped — invalid agent files produced no user feedback.

### Changes

| File | Change |
|------|--------|
| `src/index.tsx` | Call `extractAgentRegistry()` at startup, pass registry + warnings to `<App>` |
| `src/tui/types.ts` | Add `agentRegistry` (required) and `agentWarnings` to `AppProps` |
| `src/tui/index.tsx` | Thread registry to `useAgentSubmit`, show warnings as toasts on mount |
| `src/tui/hooks/use-agent-submit.ts` | Accept `agentRegistry` (required), pass to `runAgent()` |

### Verification

- `bun run lint` — passes (no new warnings)
- `bun run check:types` — no `src/` errors (playground/ pre-existing only)
- Code-reviewer agent: no critical/warning findings (one warning fixed: made `agentRegistry` required in hook props)

### Net change

4 files, +43 −2 lines

Closes foundation prerequisite for #117. Next: Workstream 2 (@agent mentions) and Workstream 3 (subagent visibility).