### PR TITLE
feat(tui): WS3 subagent execution visibility (#117)

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -117,6 +117,18 @@ export type RunAgentArgs = {
    */
   continuationHint?: string;
 
+  /** Subagent progress callback — forwarded to ToolContext for task tool visibility */
+  onSubagentProgress?: (
+    toolCallIndex: number,
+    event: import('./types').SubagentProgressEvent,
+  ) => void;
+
+  /** Subagent confirmation callback — forwarded to ToolContext for task tool confirmation */
+  onSubagentConfirmation?: (
+    toolCallIndex: number,
+    request: ConfirmationRequest,
+  ) => Promise<ConfirmationResponse>;
+
   /**
    * Called after each tool iteration with the current message array
    * (system prompt stripped) and token counts from the latest model
@@ -567,6 +579,8 @@ export async function runAgent(
             callerPermission: permissionConfig,
             runSubagent: runAgent,
             delegationDepth: args.delegationDepth ?? 0,
+            onSubagentProgress: args.onSubagentProgress,
+            onSubagentConfirmation: args.onSubagentConfirmation,
           },
         },
       );

--- a/src/agent/tool-processor.ts
+++ b/src/agent/tool-processor.ts
@@ -345,7 +345,10 @@ async function processSingleToolCall(
     }
   }
 
-  // Step 4: Execute the tool
+  // Step 4: Execute the tool (shallow-clone context with per-call index)
+  const callContext = context
+    ? { ...context, toolCallIndex: index }
+    : undefined;
   return executeToolCall(
     toolName,
     toolArgs,
@@ -354,7 +357,7 @@ async function processSingleToolCall(
     callbacks,
     index,
     signal,
-    context,
+    callContext,
   );
 }
 

--- a/src/agent/tools/task.ts
+++ b/src/agent/tools/task.ts
@@ -13,6 +13,7 @@ import { fromConfig, evaluate } from '../permission/index';
 import type { PermissionConfig } from '../permission/types';
 import { buildExplorePrompt } from '../prompts/explore';
 import { getDefaultContext, getSystemPromptForAgent } from '../prompts';
+import type { ConfirmationRequest } from '../safety/types';
 import type { ToolDefinition } from '../types';
 
 // ============================================================================
@@ -295,6 +296,9 @@ export const taskTool: ToolDefinition<typeof taskInput, typeof taskOutput> = {
 
     // --- Run subagent ---
     const filesExplored: string[] = [];
+    const toolCallIndex = context?.toolCallIndex;
+    let currentStreamingContent = '';
+    let currentIteration = 0;
 
     try {
       const result = await runSubagent({
@@ -306,8 +310,16 @@ export const taskTool: ToolDefinition<typeof taskInput, typeof taskOutput> = {
         agentRegistry: registry,
         delegationDepth: currentDepth + 1,
 
-        // Silent callbacks — don't stream to parent
-        onReasoningToken: () => {},
+        // Progress-reporting callbacks (→ TUI via context)
+        onReasoningToken: (token: string) => {
+          currentStreamingContent += token;
+          if (toolCallIndex !== undefined) {
+            context?.onSubagentProgress?.(toolCallIndex, {
+              type: 'reasoning',
+              content: currentStreamingContent,
+            });
+          }
+        },
         onToolCall: (call: {
           function: { name: string; arguments: unknown };
         }) => {
@@ -318,9 +330,44 @@ export const taskTool: ToolDefinition<typeof taskInput, typeof taskOutput> = {
               filesExplored.push(args.path);
             }
           }
+          if (toolCallIndex !== undefined) {
+            context?.onSubagentProgress?.(toolCallIndex, {
+              type: 'tool_call',
+              tool: call.function.name,
+              args: call.function.arguments as Record<string, unknown>,
+            });
+          }
         },
-        onToolResult: () => {},
-        onStepComplete: () => {},
+        onToolResult: (
+          result: { tool: string; output: string; error?: string },
+          _index: number,
+        ) => {
+          if (toolCallIndex !== undefined) {
+            context?.onSubagentProgress?.(toolCallIndex, {
+              type: 'tool_result',
+              tool: result.tool,
+              output: result.output,
+              error: result.error,
+            });
+          }
+        },
+        onStepComplete: () => {
+          currentIteration++;
+          currentStreamingContent = '';
+          if (toolCallIndex !== undefined) {
+            context?.onSubagentProgress?.(toolCallIndex, {
+              type: 'step_complete',
+              iteration: currentIteration,
+            });
+          }
+        },
+
+        // Forward confirmation to parent TUI
+        onConfirmationNeeded:
+          toolCallIndex !== undefined && context?.onSubagentConfirmation
+            ? async (request: ConfirmationRequest) =>
+                context!.onSubagentConfirmation!(toolCallIndex, request)
+            : undefined,
 
         signal: signal ?? new AbortController().signal,
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -74,6 +74,18 @@ export type ToolContext = {
    * Capped at MAX_DELEGATION_DEPTH to prevent unbounded recursion.
    */
   delegationDepth?: number;
+  /** Index of the current tool call (set by tool-processor per invocation) */
+  toolCallIndex?: number;
+  /** Subagent progress callback (task tool → TUI) */
+  onSubagentProgress?: (
+    toolCallIndex: number,
+    event: SubagentProgressEvent,
+  ) => void;
+  /** Forward subagent confirmation to parent TUI */
+  onSubagentConfirmation?: (
+    toolCallIndex: number,
+    request: import('./safety/types').ConfirmationRequest,
+  ) => Promise<import('./safety/types').ConfirmationResponse>;
 };
 
 /**
@@ -223,6 +235,18 @@ export type AgentConfig = {
  *
  * autoCompaction enabled by default at 80% context usage threshold.
  */
+/**
+ * Events emitted by a running subagent for progress visibility.
+ * Consumed by both Path A (collapsed line metadata) and Path B (overlay stream store).
+ */
+export type SubagentProgressEvent =
+  | { type: 'reasoning'; content: string }
+  | { type: 'tool_call'; tool: string; args: Record<string, unknown> }
+  | { type: 'tool_result'; tool: string; output: string; error?: string }
+  | { type: 'step_complete'; iteration: number }
+  | { type: 'awaiting_confirmation'; tool: string }
+  | { type: 'confirmation_resolved'; tool: string; action: string };
+
 export const DEFAULT_AGENT_CONFIG: AgentConfig = {
   maxIterations: 50,
   loopDetection: true,

--- a/src/tui/components/chat-screen.tsx
+++ b/src/tui/components/chat-screen.tsx
@@ -29,6 +29,7 @@ import { MentionPicker } from './mention-picker';
 import { InputBox } from './input-box';
 import { SidePanel } from './side-panel';
 import { ToastNotification } from './toast-notification';
+import { SubagentOverlay } from './subagent-overlay';
 import { ToolMessage } from './tool-message';
 import { UserMessage } from './user-message';
 
@@ -83,6 +84,11 @@ export interface ChatScreenProps {
   sidebarTodos: Accessor<Todo[]>;
   mcpStatus: Accessor<McpStatusMap>;
   mcpConnecting: Accessor<boolean>;
+
+  // Subagent overlay
+  activeOverlayToolId: Accessor<string | null>;
+  onOpenSubagentOverlay: (toolId: string) => void;
+  onCloseSubagentOverlay: () => void;
 
   // Toast
   toast: Accessor<string | null>;
@@ -155,6 +161,7 @@ export function ChatScreen(props: ChatScreenProps) {
                         props.onToolConfirmation(response);
                       }}
                       expanded={props.toolsExpanded()}
+                      onOpenOverlay={props.onOpenSubagentOverlay}
                     />
                   </Show>
                   <Show when={msg.type === 'compaction_summary' && msg}>
@@ -251,6 +258,16 @@ export function ChatScreen(props: ChatScreenProps) {
             message={msg()}
             duration={props.toastDuration}
             onDismiss={props.onToastDismiss}
+          />
+        )}
+      </Show>
+
+      <Show when={props.activeOverlayToolId()}>
+        {(toolId: () => string) => (
+          <SubagentOverlay
+            toolId={toolId()}
+            onClose={props.onCloseSubagentOverlay}
+            onSwitchTask={(newId) => props.onOpenSubagentOverlay(newId)}
           />
         )}
       </Show>

--- a/src/tui/components/subagent-overlay.tsx
+++ b/src/tui/components/subagent-overlay.tsx
@@ -1,0 +1,376 @@
+/**
+ * Full-screen overlay for viewing subagent execution in real-time.
+ *
+ * Shows streaming reasoning tokens, tool calls, and tool results grouped
+ * by iteration. Supports multi-task tabs for parallel subagents.
+ *
+ * Reads from the module-level signal store (Path B) — never touches
+ * ToolState or the <For> message list.
+ */
+
+import { createMemo, For, Show } from 'solid-js';
+import { useKeyboard, useTerminalDimensions } from '@opentui/solid';
+import { RGBA, type KeyEvent } from '@opentui/core';
+import { useTheme } from '../../design';
+import { createMarkdownSyntaxStyle } from '../utils';
+import { useOverlay } from '../hooks/use-overlay';
+import {
+  getAllSubagentIds,
+  getSubagentStream,
+  type SubagentStream,
+  type SubagentStreamEvent,
+} from '../hooks/use-subagent-streams';
+
+export type SubagentOverlayProps = {
+  toolId: string;
+  onClose: () => void;
+  onSwitchTask: (toolId: string) => void;
+};
+
+/**
+ * Format a stream event into a display line.
+ */
+function formatEvent(event: SubagentStreamEvent): {
+  icon: string;
+  text: string;
+  color: 'muted' | 'base' | 'success' | 'error' | 'warning';
+} {
+  switch (event.type) {
+    case 'tool_call': {
+      const argHint = formatArgHint(event.args);
+      return {
+        icon: '\u25D0',
+        text: `${event.tool}${argHint ? ` ${argHint}` : ''}`,
+        color: 'warning',
+      };
+    }
+    case 'tool_result':
+      return {
+        icon: event.error ? '\u2717' : '\u2713',
+        text: event.error
+          ? `${event.tool}: ${event.error}`
+          : `${event.tool} (${event.output.length} chars)`,
+        color: event.error ? 'error' : 'success',
+      };
+    case 'awaiting_confirmation':
+      return {
+        icon: '\u23F3',
+        text: `Awaiting approval for ${event.tool} in main chat...`,
+        color: 'warning',
+      };
+    case 'confirmation_resolved':
+      return {
+        icon: event.action === 'deny' ? '\u2298' : '\u2713',
+        text: `${event.tool} ${event.action === 'deny' ? 'denied' : 'approved'}`,
+        color: event.action === 'deny' ? 'muted' : 'success',
+      };
+    case 'step_complete':
+    case 'reasoning':
+      // These are handled specially (iteration headers / streaming content)
+      return { icon: '', text: '', color: 'muted' };
+  }
+}
+
+/**
+ * Extract a short hint from tool args for display.
+ */
+function formatArgHint(args: Record<string, unknown>): string {
+  const path =
+    args.path ?? args.filePath ?? args.file_path ?? args.pattern ?? args.url;
+  if (typeof path === 'string') {
+    return path.length > 50 ? `...${path.slice(-47)}` : path;
+  }
+  const cmd = args.command;
+  if (typeof cmd === 'string') {
+    return `$ ${cmd.length > 45 ? `${cmd.slice(0, 45)}...` : cmd}`;
+  }
+  return '';
+}
+
+/**
+ * Group events by iteration for display.
+ */
+type IterationGroup = {
+  iteration: number;
+  events: SubagentStreamEvent[];
+};
+
+function groupByIteration(events: SubagentStreamEvent[]): IterationGroup[] {
+  const groups: IterationGroup[] = [];
+  let current: IterationGroup = { iteration: 0, events: [] };
+
+  for (const event of events) {
+    if (event.type === 'step_complete') {
+      // Push current group and start new one
+      if (current.events.length > 0) {
+        groups.push(current);
+      }
+      current = { iteration: event.iteration, events: [] };
+    } else if (event.type !== 'reasoning') {
+      // Skip reasoning events — streaming content is shown separately
+      current.events.push(event);
+    }
+  }
+
+  // Push final group
+  if (current.events.length > 0) {
+    groups.push(current);
+  }
+
+  return groups;
+}
+
+export function SubagentOverlay(props: SubagentOverlayProps) {
+  const { tokens } = useTheme();
+  const dimensions = useTerminalDimensions();
+  const markdownStyle = createMemo(() => createMarkdownSyntaxStyle(tokens));
+
+  // Register overlay — blocks app-level keyboard handlers
+  useOverlay();
+
+  // Keyboard handling — Esc closes, arrows switch tabs
+  useKeyboard((key: KeyEvent) => {
+    key.stopPropagation();
+    if (key.name === 'escape') {
+      props.onClose();
+      return;
+    }
+    if (key.name === 'left' || key.name === 'right' || key.name === 'tab') {
+      const ids = getAllSubagentIds();
+      const currentIdx = ids.indexOf(props.toolId);
+      if (currentIdx === -1 || ids.length <= 1) return;
+      const next =
+        key.name === 'left'
+          ? (currentIdx - 1 + ids.length) % ids.length
+          : (currentIdx + 1) % ids.length;
+      const nextId = ids[next];
+      if (nextId) props.onSwitchTask(nextId);
+    }
+  });
+
+  // Read stream from Path B store
+  const stream = createMemo<SubagentStream | undefined>(() =>
+    getSubagentStream(props.toolId),
+  );
+
+  const iterationGroups = createMemo(() => {
+    const s = stream();
+    if (!s) return [];
+    return groupByIteration(s.events);
+  });
+
+  const activeIds = createMemo(() => getAllSubagentIds());
+
+  const colorFor = (
+    c: 'muted' | 'base' | 'success' | 'error' | 'warning',
+  ): string => {
+    switch (c) {
+      case 'muted':
+        return tokens.textMuted;
+      case 'base':
+        return tokens.textBase;
+      case 'success':
+        return tokens.success;
+      case 'error':
+        return tokens.error;
+      case 'warning':
+        return tokens.warning;
+    }
+  };
+
+  return (
+    <>
+      {/* Backdrop */}
+      <box
+        style={{
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: dimensions().width,
+          height: dimensions().height,
+          zIndex: 200,
+          backgroundColor: RGBA.fromInts(0, 0, 0, 220),
+        }}
+      />
+
+      {/* Overlay panel */}
+      <box
+        style={{
+          position: 'absolute',
+          left: 1,
+          top: 1,
+          width: dimensions().width - 2,
+          height: dimensions().height - 2,
+          zIndex: 201,
+          backgroundColor: tokens.bgBase,
+          flexDirection: 'column',
+          border: true,
+          borderStyle: 'rounded',
+          borderColor: tokens.borderMuted,
+        }}
+      >
+        {/* Header with tabs */}
+        <box
+          style={{
+            flexDirection: 'row',
+            paddingX: 1,
+            border: ['bottom'],
+            borderColor: tokens.borderMuted,
+            flexShrink: 0,
+          }}
+        >
+          <box onMouseDown={() => props.onClose()} style={{ marginRight: 2 }}>
+            <text style={{ fg: tokens.textMuted }}>{'\u2190 Back (Esc)'}</text>
+          </box>
+
+          {/* Tab bar */}
+          <For each={activeIds()}>
+            {(id) => {
+              const tabStream = createMemo(() => getSubagentStream(id));
+              const isActive = () => id === props.toolId;
+              const statusIcon = () => {
+                const s = tabStream();
+                if (!s) return '\u25CF';
+                switch (s.status) {
+                  case 'completed':
+                    return '\u2713';
+                  case 'failed':
+                    return '\u2717';
+                  case 'awaiting_confirmation':
+                    return '\u23F3';
+                  default:
+                    return '\u25CF';
+                }
+              };
+
+              return (
+                <box
+                  onMouseDown={() => props.onSwitchTask(id)}
+                  style={{
+                    marginLeft: 1,
+                    paddingX: 1,
+                    backgroundColor: isActive()
+                      ? tokens.bgSurface
+                      : tokens.bgBase,
+                  }}
+                >
+                  <text
+                    style={{
+                      fg: isActive() ? tokens.primaryBase : tokens.textMuted,
+                    }}
+                  >
+                    {`${statusIcon()} @${tabStream()?.agentName ?? 'unknown'} ${tabStream()?.iteration ?? 0}/${tabStream()?.maxIterations ?? '?'}`}
+                  </text>
+                </box>
+              );
+            }}
+          </For>
+        </box>
+
+        {/* Current task description */}
+        <Show when={stream()}>
+          {(s: () => SubagentStream) => (
+            <box
+              style={{
+                paddingX: 2,
+                paddingY: 1,
+                border: ['bottom'],
+                borderColor: tokens.borderMuted,
+                flexShrink: 0,
+              }}
+            >
+              <text style={{ fg: tokens.primaryBase }}>
+                {`@${s().agentName}`}
+              </text>
+              <text style={{ fg: tokens.textMuted }}>
+                {` "${s().description}" - Iteration ${s().iteration}/${s().maxIterations}`}
+              </text>
+            </box>
+          )}
+        </Show>
+
+        {/* Event stream */}
+        <scrollbox
+          flexGrow={1}
+          flexShrink={1}
+          stickyScroll={true}
+          stickyStart="bottom"
+        >
+          <box style={{ flexDirection: 'column', paddingX: 2, paddingY: 1 }}>
+            <For each={iterationGroups()}>
+              {(group) => (
+                <box style={{ flexDirection: 'column', marginBottom: 1 }}>
+                  {/* Iteration separator */}
+                  <box style={{ marginBottom: 1 }}>
+                    <text style={{ fg: tokens.textMuted }}>
+                      {`── Iteration ${group.iteration + 1} ──`}
+                    </text>
+                  </box>
+
+                  {/* Events in this iteration */}
+                  <For each={group.events}>
+                    {(event) => {
+                      const formatted = formatEvent(event);
+                      return (
+                        <Show when={formatted.text}>
+                          <box style={{ flexDirection: 'row', marginLeft: 1 }}>
+                            <text style={{ fg: colorFor(formatted.color) }}>
+                              {`${formatted.icon} `}
+                            </text>
+                            <text style={{ fg: colorFor(formatted.color) }}>
+                              {formatted.text}
+                            </text>
+                          </box>
+                        </Show>
+                      );
+                    }}
+                  </For>
+                </box>
+              )}
+            </For>
+
+            {/* Current streaming content */}
+            <Show when={stream()?.streamingContent}>
+              {(content: () => string) => (
+                <box style={{ marginLeft: 1, marginTop: 1 }}>
+                  <markdown
+                    content={content()}
+                    syntaxStyle={markdownStyle()}
+                    streaming={true}
+                    conceal={true}
+                  />
+                </box>
+              )}
+            </Show>
+
+            {/* Status indicator when awaiting confirmation */}
+            <Show when={stream()?.status === 'awaiting_confirmation'}>
+              <box style={{ marginTop: 1 }}>
+                <text style={{ fg: tokens.warning }}>
+                  {'\u23F3 Awaiting tool approval in main chat...'}
+                </text>
+              </box>
+            </Show>
+          </box>
+        </scrollbox>
+
+        {/* Footer */}
+        <box
+          style={{
+            paddingX: 2,
+            paddingY: 1,
+            border: ['top'],
+            borderColor: tokens.borderMuted,
+            flexShrink: 0,
+          }}
+        >
+          <text style={{ fg: tokens.textMuted }}>
+            {activeIds().length > 1
+              ? 'Esc close \u00B7 \u2190/\u2192 switch tasks \u00B7 Tab next task'
+              : 'Press Esc to close'}
+          </text>
+        </box>
+      </box>
+    </>
+  );
+}

--- a/src/tui/components/tool-message.tsx
+++ b/src/tui/components/tool-message.tsx
@@ -7,7 +7,7 @@
  */
 
 import type { JSX } from 'solid-js';
-import { Show } from 'solid-js';
+import { createSignal, onCleanup, Show } from 'solid-js';
 import type { KeyEvent } from '@opentui/core';
 import { useKeyboard } from '@opentui/solid';
 import type { ConfirmationResponse } from '../../agent/safety/types';
@@ -26,6 +26,8 @@ export type ToolMessageProps = {
   isActiveConfirmation?: boolean;
   /** Whether to show expanded output for read-only tools (toggle with Ctrl+E) */
   expanded?: boolean;
+  /** Called when user clicks a task tool line to open the subagent overlay */
+  onOpenOverlay?: (toolId: string) => void;
 };
 
 /** Read-only tools that support expand/collapse */
@@ -616,6 +618,85 @@ function ExpandableTool(props: {
 }
 
 /**
+ * Animated pending/executing view for task tools (subagent delegation).
+ * Shows a braille spinner, iteration progress, and current tool activity.
+ * Clicking opens the subagent overlay.
+ */
+function TaskPendingTool(props: {
+  message: ToolDisplayMessage;
+  tokens: SemanticTokens;
+  onOpenOverlay?: (toolId: string) => void;
+}) {
+  // Braille spinner animation
+  const BRAILLE = [
+    '\u280B',
+    '\u2819',
+    '\u2839',
+    '\u2838',
+    '\u283C',
+    '\u2834',
+    '\u2826',
+    '\u2827',
+    '\u2807',
+    '\u280F',
+  ];
+  const [frame, setFrame] = createSignal(0);
+  const interval = setInterval(
+    () => setFrame((f) => (f + 1) % BRAILLE.length),
+    80,
+  );
+  onCleanup(() => clearInterval(interval));
+
+  // Read progress from executing state metadata (Path A)
+  const progress = () => {
+    const state = props.message.state;
+    if (state.status === 'executing' && state.metadata?.subagentProgress) {
+      return state.metadata.subagentProgress;
+    }
+    return undefined;
+  };
+
+  const header = () => formatToolHeader(props.message.name, props.message.args);
+  const spinner = () => BRAILLE[frame()] ?? '\u280B';
+
+  return (
+    <box
+      style={{
+        backgroundColor: props.tokens.bgSurface,
+        padding: 1,
+        border: ['left'],
+        borderStyle: 'heavy',
+        borderColor: props.tokens.warning,
+      }}
+      onMouseDown={() => props.onOpenOverlay?.(props.message.id)}
+    >
+      <box style={{ flexDirection: 'row' }}>
+        <text style={{ fg: props.tokens.warning }}>{spinner()} </text>
+        <text style={{ fg: props.tokens.primaryBase }}>task</text>
+        <text style={{ fg: props.tokens.textMuted }}> {header()}</text>
+        <Show when={progress()}>
+          {(p: () => NonNullable<ReturnType<typeof progress>>) => (
+            <text style={{ fg: props.tokens.primaryBase }}>
+              {` @${p().agentName} ${p().iteration}/${p().maxIterations}`}
+            </text>
+          )}
+        </Show>
+        <text style={{ fg: props.tokens.textMuted }}> [click or Ctrl+T]</text>
+      </box>
+      <Show when={progress()?.currentActivity}>
+        {(activity: () => string) => (
+          <box style={{ marginLeft: 3 }}>
+            <text style={{ fg: props.tokens.textMuted }}>
+              {`\u2514 ${activity()}`}
+            </text>
+          </box>
+        )}
+      </Show>
+    </box>
+  );
+}
+
+/**
  * Main ToolMessage component.
  */
 export function ToolMessage(props: ToolMessageProps) {
@@ -635,6 +716,15 @@ export function ToolMessage(props: ToolMessageProps) {
   switch (props.message.state.status) {
     case 'pending':
     case 'executing':
+      if (props.message.name === 'task') {
+        return (
+          <TaskPendingTool
+            message={props.message}
+            tokens={tokens}
+            onOpenOverlay={props.onOpenOverlay}
+          />
+        );
+      }
       return (
         <InlineTool
           icon={icon}
@@ -668,6 +758,41 @@ export function ToolMessage(props: ToolMessageProps) {
       }
       if (props.message.name === 'run_command') {
         return <CommandCompleted message={props.message} tokens={tokens} />;
+      }
+
+      // Completed task tools: clickable to re-open overlay
+      if (props.message.name === 'task') {
+        const taskOutput = formatCompletedOutput(
+          props.message.name,
+          props.message.state.output,
+          props.message.state.metadata,
+        );
+        return (
+          <box
+            onMouseDown={() => props.onOpenOverlay?.(props.message.id)}
+            style={{
+              backgroundColor: tokens.bgSurface,
+              padding: 1,
+              border: ['left'],
+              borderStyle: 'heavy',
+              borderColor: tokens.success,
+            }}
+          >
+            <box style={{ flexDirection: 'row' }}>
+              <text style={{ fg: tokens.success }}>{'\u2713'} </text>
+              <text style={{ fg: tokens.primaryBase }}>task</text>
+              <text style={{ fg: tokens.textMuted }}> {header}</text>
+              <Show when={taskOutput}>
+                <text style={{ fg: tokens.textMuted }}>
+                  {` (${taskOutput})`}
+                </text>
+              </Show>
+              <text style={{ fg: tokens.textMuted }}>
+                {' [click or Ctrl+T]'}
+              </text>
+            </box>
+          </box>
+        );
       }
 
       // MCP tools and read-only native tools: use expand/collapse

--- a/src/tui/hooks/use-agent-submit.ts
+++ b/src/tui/hooks/use-agent-submit.ts
@@ -54,6 +54,13 @@ import type {
   ToolState,
 } from '../types';
 import type { UseMessageStoreReturn } from './use-message-store';
+import {
+  appendSubagentEvent,
+  clearCompletedStreams,
+  completeSubagentStream,
+  createSubagentStream,
+  getSubagentStream,
+} from './use-subagent-streams';
 
 export type UseAgentSubmitProps = {
   /** Resolved config (config.host is authoritative, includes OLLAMA_HOST) */
@@ -107,6 +114,22 @@ function generateToolId(): string {
   return `tool_${Date.now()}_${Math.random().toString(TOOL_ID_RADIX).slice(TOOL_ID_SLICE_START, TOOL_ID_SLICE_END)}`;
 }
 
+/** Format tool name + args into a short activity string for the collapsed line. */
+function formatToolActivity(
+  tool: string,
+  args: Record<string, unknown>,
+): string {
+  // Show the most relevant arg (path, pattern, command, etc.)
+  const path =
+    args.path ?? args.filePath ?? args.file_path ?? args.pattern ?? args.url;
+  if (typeof path === 'string') {
+    // Truncate long paths
+    const short = path.length > 40 ? `...${path.slice(-37)}` : path;
+    return `${tool} ${short}`;
+  }
+  return tool;
+}
+
 /** Notification durations (ms) */
 const NOTIFICATION_SHORT = 3000;
 const NOTIFICATION_LONG = 8000;
@@ -125,8 +148,27 @@ export function useAgentSubmit(
 
   // Plain variables replace useRef — no .current wrapper needed
   let abortController: AbortController | null = null;
-  let confirmationResolver: ((response: ConfirmationResponse) => void) | null =
-    null;
+
+  // Confirmation queue: resolvers keyed by confirmToolId, plus a FIFO queue
+  // for pending requests so parallel subagent confirmations don't clobber.
+  const confirmationResolvers = new Map<
+    string,
+    (response: ConfirmationResponse) => void
+  >();
+  type QueuedConfirmation = {
+    confirmToolId: string;
+    resolver: (response: ConfirmationResponse) => void;
+  };
+  const confirmationQueue: QueuedConfirmation[] = [];
+
+  /** Show the next queued confirmation (if any). */
+  const showNextConfirmation = () => {
+    const next = confirmationQueue.shift();
+    if (next) {
+      confirmationResolvers.set(next.confirmToolId, next.resolver);
+      setConfirmingToolId(next.confirmToolId);
+    }
+  };
 
   const abort = () => {
     abortController?.abort();
@@ -136,13 +178,21 @@ export function useAgentSubmit(
    * Handle confirmation response from the ToolMessage component.
    */
   const handleToolConfirmation = (response: ConfirmationResponse) => {
-    if (confirmationResolver) {
-      confirmationResolver(response);
-      confirmationResolver = null;
+    const activeId = confirmingToolId();
+    if (activeId) {
+      const resolver = confirmationResolvers.get(activeId);
+      if (resolver) {
+        resolver(response);
+        confirmationResolvers.delete(activeId);
+      }
     }
     // Defer clearing confirmingToolId so the textarea doesn't re-focus
     // in the same tick as the 'y'/'n' keypress that triggered confirmation.
-    queueMicrotask(() => setConfirmingToolId(null));
+    queueMicrotask(() => {
+      setConfirmingToolId(null);
+      // Process next queued confirmation after UI settles
+      queueMicrotask(showNextConfirmation);
+    });
   };
 
   /**
@@ -178,6 +228,11 @@ export function useAgentSubmit(
   const handleSubmit = async (prompt: string) => {
     setStatus('thinking');
     setStreamingContent('');
+
+    // Clear stale subagent streams from previous runs (free memory).
+    // Done at start of new run so completed streams remain viewable
+    // between runs (user can click completed task lines to re-inspect).
+    clearCompletedStreams();
 
     const session = await props.ensureSession();
 
@@ -310,6 +365,30 @@ export function useAgentSubmit(
           args: toolArgs,
           state: { status: 'pending' },
         });
+
+        // Create subagent stream for task tools (Path B — overlay data)
+        if (toolName === 'task') {
+          // Resolve maxIterations from args (matches task tool's resolveMaxIterations logic)
+          const rawMax = toolArgs.maxIterations;
+          const iterationPresets: Record<string, number> = {
+            quick: 5,
+            medium: 15,
+            thorough: 30,
+          };
+          const maxIter =
+            typeof rawMax === 'number'
+              ? rawMax
+              : typeof rawMax === 'string' && rawMax in iterationPresets
+                ? (iterationPresets[rawMax] ?? 15)
+                : 15;
+
+          createSubagentStream(
+            toolId,
+            String(toolArgs.agent ?? 'unknown'),
+            String(toolArgs.description ?? ''),
+            maxIter,
+          );
+        }
       },
       onToolResult: (result: ToolResult, index: number) => {
         // Use index for lookup (handles parallel calls to same tool)
@@ -354,6 +433,11 @@ export function useAgentSubmit(
 
         store.updatePendingToolState(toolId, finalState);
 
+        // Complete subagent stream when task tool finishes
+        if (result.tool === 'task') {
+          completeSubagentStream(toolId, result.error ? 'failed' : 'completed');
+        }
+
         // Refresh sidebar todos in real-time when todo_write completes
         if (result.tool === 'todo_write' && !result.error) {
           props.setSidebarTodos(getTodos(session.id));
@@ -390,12 +474,14 @@ export function useAgentSubmit(
             status: 'confirming',
             preview: request.preview,
           });
-          setConfirmingToolId(toolId);
         }
 
-        // Wait for user response via handleToolConfirmation
+        // Wait for user response via handleToolConfirmation (queue-safe)
+        // NOTE: setConfirmingToolId is set inside the Promise by the queue logic,
+        // NOT here — setting it here would cause the queue check to misfire.
+        const confirmId = toolId ?? generateToolId();
         return new Promise<ConfirmationResponse>((resolve) => {
-          confirmationResolver = (response) => {
+          const resolver = (response: ConfirmationResponse) => {
             // Update tool state based on response
             if (toolId) {
               if (response.action === 'deny') {
@@ -406,6 +492,98 @@ export function useAgentSubmit(
             }
             resolve(response);
           };
+
+          // If another confirmation is active, queue this one
+          if (confirmingToolId()) {
+            confirmationQueue.push({ confirmToolId: confirmId, resolver });
+          } else {
+            confirmationResolvers.set(confirmId, resolver);
+            setConfirmingToolId(confirmId);
+          }
+        });
+      },
+      onSubagentProgress: (toolCallIndex: number, event) => {
+        const toolId = toolIdsByIndex.get(toolCallIndex);
+        if (!toolId) return;
+
+        // Path B: always update overlay stream store
+        appendSubagentEvent(toolId, event);
+
+        // Path A: update collapsed line metadata on infrequent events only
+        if (event.type === 'step_complete' || event.type === 'tool_call') {
+          const stream = getSubagentStream(toolId);
+          if (stream) {
+            store.updatePendingToolMetadata(toolId, {
+              subagentProgress: {
+                iteration: stream.iteration,
+                maxIterations: stream.maxIterations,
+                currentTool:
+                  event.type === 'tool_call'
+                    ? event.tool
+                    : stream.events.filter((e) => e.type === 'tool_call').pop()
+                        ?.tool,
+                currentActivity:
+                  event.type === 'tool_call'
+                    ? formatToolActivity(
+                        event.tool,
+                        event.args as Record<string, unknown>,
+                      )
+                    : undefined,
+                agentName: stream.agentName,
+                description: stream.description,
+              },
+            });
+          }
+        }
+      },
+      onSubagentConfirmation: async (toolCallIndex: number, request) => {
+        const taskToolId = toolIdsByIndex.get(toolCallIndex);
+        if (!taskToolId) return { action: 'deny' as const };
+
+        // Mark subagent as awaiting confirmation in stream store
+        appendSubagentEvent(taskToolId, {
+          type: 'awaiting_confirmation',
+          tool: request.tool,
+        });
+
+        // Create confirmation tool message in main chat (reuses existing UI)
+        const confirmToolId = generateToolId();
+        store.addPendingToolMessage({
+          type: 'tool',
+          id: confirmToolId,
+          name: request.tool,
+          args: (request as Record<string, unknown>).args
+            ? ((request as Record<string, unknown>).args as Record<
+                string,
+                unknown
+              >)
+            : {},
+          state: { status: 'confirming', preview: request.preview },
+        });
+        // Wait for user response (queue-safe — won't clobber parallel confirmations)
+        return new Promise<ConfirmationResponse>((resolve) => {
+          const resolver = (response: ConfirmationResponse) => {
+            store.updatePendingToolState(
+              confirmToolId,
+              response.action === 'deny'
+                ? { status: 'denied' }
+                : { status: 'executing' },
+            );
+            appendSubagentEvent(taskToolId, {
+              type: 'confirmation_resolved',
+              tool: request.tool,
+              action: response.action,
+            });
+            resolve(response);
+          };
+
+          // If another confirmation is active, queue this one
+          if (confirmingToolId()) {
+            confirmationQueue.push({ confirmToolId, resolver });
+          } else {
+            confirmationResolvers.set(confirmToolId, resolver);
+            setConfirmingToolId(confirmToolId);
+          }
         });
       },
       onToolBlocked: (tool: string, reason: string) => {

--- a/src/tui/hooks/use-keyboard-shortcuts.ts
+++ b/src/tui/hooks/use-keyboard-shortcuts.ts
@@ -31,6 +31,8 @@ export type UseKeyboardShortcutsProps = {
   onClipboardNotify: (message: string) => void;
   /** TUI config for double-escape threshold */
   tuiConfig?: TuiConfig;
+  /** Toggle subagent overlay (Ctrl+T) */
+  onToggleSubagentOverlay?: () => void;
 };
 
 export type UseKeyboardShortcutsReturn = {
@@ -71,6 +73,12 @@ export function useKeyboardShortcuts(
           props.onClipboardNotify('Clipboard not supported by terminal');
         }
       }
+      return;
+    }
+
+    // Ctrl+T: Toggle subagent overlay
+    if (key.ctrl && key.name === 't') {
+      props.onToggleSubagentOverlay?.();
       return;
     }
 

--- a/src/tui/hooks/use-message-store.ts
+++ b/src/tui/hooks/use-message-store.ts
@@ -91,6 +91,11 @@ export type UseMessageStoreReturn = {
   addPendingToolMessage: (msg: ToolDisplayMessage) => void;
   /** Update a pending tool message's state by ID */
   updatePendingToolState: (toolId: string, newState: ToolState) => void;
+  /** Update metadata on a pending tool in executing state (Path A — infrequent) */
+  updatePendingToolMetadata: (
+    toolId: string,
+    metadata: Partial<import('../types').ToolMetadata>,
+  ) => void;
   /** Add a pending assistant message (e.g., final answer before settlement) */
   addPendingAssistantMessage: (content: string) => void;
   /** Read current pending display messages (for building ToolParts in callbacks) */
@@ -274,6 +279,35 @@ export function useMessageStore(): UseMessageStoreReturn {
     );
   };
 
+  const updatePendingToolMetadata = (
+    toolId: string,
+    metadata: Partial<import('../types').ToolMetadata>,
+  ): void => {
+    setPendingDisplayMessages((prev) =>
+      prev.map((msg) => {
+        if (msg.type !== 'tool' || msg.id !== toolId) return msg;
+        const { status } = msg.state;
+        // Allow metadata on pending (promote to executing) and executing states
+        if (status === 'pending') {
+          return {
+            ...msg,
+            state: { status: 'executing' as const, metadata: { ...metadata } },
+          };
+        }
+        if (status === 'executing') {
+          return {
+            ...msg,
+            state: {
+              ...msg.state,
+              metadata: { ...msg.state.metadata, ...metadata },
+            },
+          };
+        }
+        return msg;
+      }),
+    );
+  };
+
   const addPendingAssistantMessage = (content: string): void => {
     setPendingDisplayMessages((prev) => [
       ...prev,
@@ -347,6 +381,7 @@ export function useMessageStore(): UseMessageStoreReturn {
     settleAgentError,
     addPendingToolMessage,
     updatePendingToolState,
+    updatePendingToolMetadata,
     addPendingAssistantMessage,
     getPendingDisplayMessages,
     clear,

--- a/src/tui/hooks/use-subagent-streams.ts
+++ b/src/tui/hooks/use-subagent-streams.ts
@@ -1,0 +1,171 @@
+/**
+ * Module-level signal store for subagent overlay streaming data (Path B).
+ *
+ * Same pattern as use-overlay.ts — module-level signals, no context provider.
+ * This store holds the full event history for each running subagent,
+ * read only by the overlay component. High-frequency updates (reasoning tokens)
+ * go here and never touch ToolState / the <For> message list.
+ */
+
+import { createSignal } from 'solid-js';
+
+import type { SubagentProgressEvent } from '../../agent/types';
+
+export type SubagentStreamEvent = SubagentProgressEvent & { timestamp: number };
+
+export type SubagentStream = {
+  toolId: string;
+  agentName: string;
+  description: string;
+  maxIterations: number;
+  events: SubagentStreamEvent[];
+  /** Current iteration reasoning accumulator (reset on step_complete) */
+  streamingContent: string;
+  iteration: number;
+  status: 'running' | 'awaiting_confirmation' | 'completed' | 'failed';
+};
+
+// ---------------------------------------------------------------------------
+// Module-level signal — shared across all components that import this file
+// ---------------------------------------------------------------------------
+const [streams, setStreams] = createSignal<Map<string, SubagentStream>>(
+  new Map(),
+);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Create a new stream entry when a task tool starts. */
+export function createSubagentStream(
+  toolId: string,
+  agentName: string,
+  description: string,
+  maxIterations: number,
+): void {
+  setStreams((prev) => {
+    const next = new Map(prev);
+    next.set(toolId, {
+      toolId,
+      agentName,
+      description,
+      maxIterations,
+      events: [],
+      streamingContent: '',
+      iteration: 0,
+      status: 'running',
+    });
+    return next;
+  });
+}
+
+/** Append a progress event to an existing stream. */
+export function appendSubagentEvent(
+  toolId: string,
+  event: SubagentProgressEvent,
+): void {
+  setStreams((prev) => {
+    const existing = prev.get(toolId);
+    if (!existing) return prev;
+
+    const next = new Map(prev);
+    const updated = { ...existing };
+
+    // Update derived fields based on event type.
+    // Reasoning events only update the streaming accumulator — they are NOT
+    // stored in the events array (avoids O(n^2) memory from accumulating
+    // the full content string in every event).
+    switch (event.type) {
+      case 'reasoning':
+        updated.streamingContent = event.content;
+        break;
+      case 'step_complete':
+        updated.iteration = event.iteration;
+        updated.streamingContent = '';
+        updated.events = [
+          ...existing.events,
+          { ...event, timestamp: Date.now() },
+        ];
+        break;
+      case 'awaiting_confirmation':
+        updated.status = 'awaiting_confirmation';
+        updated.events = [
+          ...existing.events,
+          { ...event, timestamp: Date.now() },
+        ];
+        break;
+      case 'confirmation_resolved':
+        updated.status = 'running';
+        updated.events = [
+          ...existing.events,
+          { ...event, timestamp: Date.now() },
+        ];
+        break;
+      default:
+        // tool_call, tool_result — append to events
+        updated.events = [
+          ...existing.events,
+          { ...event, timestamp: Date.now() },
+        ];
+        break;
+    }
+
+    next.set(toolId, updated);
+    return next;
+  });
+}
+
+/** Mark a stream as completed or failed. */
+export function completeSubagentStream(
+  toolId: string,
+  status: 'completed' | 'failed',
+): void {
+  setStreams((prev) => {
+    const existing = prev.get(toolId);
+    if (!existing) return prev;
+
+    const next = new Map(prev);
+    next.set(toolId, { ...existing, status });
+    return next;
+  });
+}
+
+/** Get a single stream by toolId. */
+export function getSubagentStream(toolId: string): SubagentStream | undefined {
+  return streams().get(toolId);
+}
+
+/** Get toolIds of all active (non-completed) subagent streams. */
+export function getActiveSubagentIds(): string[] {
+  const result: string[] = [];
+  for (const [id, stream] of streams()) {
+    if (
+      stream.status === 'running' ||
+      stream.status === 'awaiting_confirmation'
+    ) {
+      result.push(id);
+    }
+  }
+  return result;
+}
+
+/** Get toolIds of ALL subagent streams (including completed/failed). */
+export function getAllSubagentIds(): string[] {
+  return [...streams().keys()];
+}
+
+/** Remove completed/failed streams (call after overlay closes). */
+export function clearCompletedStreams(): void {
+  setStreams((prev) => {
+    const next = new Map<string, SubagentStream>();
+    for (const [id, stream] of prev) {
+      if (
+        stream.status === 'running' ||
+        stream.status === 'awaiting_confirmation'
+      ) {
+        next.set(id, stream);
+      }
+    }
+    return next;
+  });
+}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -19,6 +19,7 @@ import {
   useSession,
 } from './hooks';
 import { useMessageStore } from './hooks/use-message-store';
+import { getAllSubagentIds } from './hooks/use-subagent-streams';
 import type { AppProps, Status } from './types';
 
 /** Frame rate targets for terminal focus power-saving */
@@ -71,6 +72,9 @@ function AppContent(props: AppProps) {
   const [toast, setToast] = createSignal<string | null>(null);
   const [showConfigModal, setShowConfigModal] = createSignal(false);
   const [showMcpModal, setShowMcpModal] = createSignal(false);
+  const [activeOverlayToolId, setActiveOverlayToolId] = createSignal<
+    string | null
+  >(null);
 
   // MCP hook — connects servers, registers tools, provides reactive status
   const mcp = useMcp({
@@ -161,6 +165,16 @@ function AppContent(props: AppProps) {
     currentSession: session.currentSession,
     onClipboardNotify: (message: string) => setToast(message),
     tuiConfig: tuiConfig(),
+    onToggleSubagentOverlay: () => {
+      if (activeOverlayToolId()) {
+        setActiveOverlayToolId(null);
+      } else {
+        const allIds = getAllSubagentIds();
+        if (allIds.length > 0) {
+          setActiveOverlayToolId(allIds[0] ?? null);
+        }
+      }
+    },
   });
 
   // Surface agent loader warnings as toasts on startup
@@ -284,6 +298,9 @@ function AppContent(props: AppProps) {
           sidebarTodos={session.sidebarTodos}
           mcpStatus={mcp.mcpStatus}
           mcpConnecting={mcp.connecting}
+          activeOverlayToolId={activeOverlayToolId}
+          onOpenSubagentOverlay={(toolId) => setActiveOverlayToolId(toolId)}
+          onCloseSubagentOverlay={() => setActiveOverlayToolId(null)}
           toast={toast}
           toastDuration={tuiConfig().toastDuration}
           onToastDismiss={() => setToast(null)}

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -31,7 +31,7 @@ export type Status = 'idle' | 'thinking';
 export type ToolState =
   | { status: 'pending' }
   | { status: 'confirming'; preview?: ConfirmationPreview }
-  | { status: 'executing' }
+  | { status: 'executing'; metadata?: ToolMetadata }
   | { status: 'completed'; output: string; metadata?: ToolMetadata }
   | { status: 'error'; error: string }
   | { status: 'denied'; reason?: string }
@@ -54,6 +54,21 @@ export type ToolMetadata = {
   matchCount?: number;
   /** Line count for read_file */
   lineCount?: number;
+  /** Live progress for task tool (subagent execution) */
+  subagentProgress?: SubagentProgress;
+};
+
+/**
+ * Live progress data for a running subagent (task tool).
+ * Stored in ToolMetadata on the executing state (Path A — infrequent updates).
+ */
+export type SubagentProgress = {
+  iteration: number;
+  maxIterations: number;
+  currentTool?: string;
+  currentActivity?: string;
+  agentName: string;
+  description: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

Implements WS3 (Subagent Execution Visibility) from issue #117. When the `task` tool runs a subagent, the user now gets real-time visibility into what's happening.

## What's New

- **Animated collapsed task line** — Braille spinner + iteration counter + current tool activity
- **Full-screen overlay** — Click task line or Ctrl+T to see streaming reasoning, tool calls, and results grouped by iteration
- **Multi-subagent tabs** — ←/→/Tab to switch between parallel running subagents, mouse click support
- **Confirmation forwarding** — Subagent tool confirmations surface in main chat via existing ConfirmingView
- **Re-inspectable** — Completed task lines remain clickable to re-open overlay with full event history (until next agent run)

## Architecture

- **Two data paths** — Path A (ToolMetadata on executing state, infrequent updates for collapsed line) and Path B (module-level signal store for overlay streaming) prevent streaming tokens from triggering `<For>` recreation
- **Confirmation queue** — Map + FIFO queue prevents resolver clobbering when parallel subagents both need confirmation
- **Memory safety** — Reasoning events excluded from event array (O(n) not O(n²)), completed streams cleaned up at start of next run

## Files Changed

- 11 modified, 2 new (`subagent-overlay.tsx`, `use-subagent-streams.ts`)
- **Not touched**: ExpandableTool, completed rendering for non-task tools, ConfirmingView, ctrl+e, stream-handler.ts

## Verification

- `bun run check:types` — 0 non-playground errors
- `bun run lint` — 0 errors (warnings/infos pre-existing)
- Code reviewer agent: 3 critical issues found and fixed (confirmation race, unbounded events, O(n²) reasoning)
- Manual testing: confirmation flow, overlay open/close, completed task re-inspection

Closes #117