### PR TITLE
feat: add web_search tool using Ollama web search API

### DIFF
--- a/src/agent/agents/builtins.ts
+++ b/src/agent/agents/builtins.ts
@@ -47,6 +47,7 @@ const EXPLORE_PERMISSIONS: PermissionConfig = {
   list: 'allow',
   bash: 'allow',
   web_fetch: 'allow',
+  web_search: 'allow',
   todo: 'allow',
 };
 

--- a/src/agent/agents/schema.ts
+++ b/src/agent/agents/schema.ts
@@ -85,6 +85,7 @@ export const PERMISSION_KEY_TO_TOOLS: Record<string, readonly string[]> = {
   task: ['task'],
   todo: ['todo_write', 'todo_read'],
   web_fetch: ['web_fetch'],
+  web_search: ['web_search'],
   // 'mcp' and '*' are handled specially — not in this map
 };
 

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -15,6 +15,7 @@ import { runCommandTool } from './run-command';
 import { taskTool, buildTaskToolDescription } from './task';
 import { todoReadTool, todoWriteTool } from './todo';
 import { webFetchTool } from './web-fetch';
+import { webSearchTool } from './web-search';
 import { writeFileTool } from './write-file';
 
 // All registered tools — mutable to allow MCP tool registration/unregistration
@@ -31,6 +32,7 @@ const tools: ToolDefinition<any, any>[] = [
   todoReadTool,
   taskTool,
   webFetchTool,
+  webSearchTool,
 ];
 
 /**
@@ -55,6 +57,7 @@ export const TOOL_NAMES = {
   TODO_READ: 'todo_read',
   TASK: 'task',
   WEB_FETCH: 'web_fetch',
+  WEB_SEARCH: 'web_search',
 } as const;
 
 // Convert ToolDefinition to Ollama Tool format

--- a/src/agent/tools/web-search.ts
+++ b/src/agent/tools/web-search.ts
@@ -1,0 +1,212 @@
+/**
+ * Web Search Tool - Searches the web via Ollama's web search API.
+ *
+ * Handles **discovery** — finding relevant URLs and snippets for a query.
+ * Complements the existing web_fetch tool which handles **retrieval** of
+ * full page content from a known URL.
+ *
+ * Uses the Ollama web search endpoint (POST /api/web_search) with the
+ * existing OLLAMA_API_KEY environment variable.
+ */
+
+import { z } from 'zod';
+import type { ToolDefinition } from '../types';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_MAX_RESULTS = 5;
+const MAX_RESULTS_LIMIT = 10;
+const SEARCH_TIMEOUT_MS = 25_000;
+
+const OLLAMA_SEARCH_URL = 'https://ollama.com/api/web_search';
+
+// ============================================================================
+// Schemas
+// ============================================================================
+
+const inputSchema = z.object({
+  query: z.string().describe('The search query'),
+  max_results: z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_RESULTS_LIMIT)
+    .optional()
+    .default(DEFAULT_MAX_RESULTS)
+    .describe(
+      `Number of results to return (default ${DEFAULT_MAX_RESULTS}, max ${MAX_RESULTS_LIMIT})`,
+    ),
+});
+
+const outputSchema = z
+  .string()
+  .describe('Search results formatted as markdown');
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type SearchResult = {
+  title: string;
+  url: string;
+  content: string;
+};
+
+type SearchResponse = {
+  results: SearchResult[];
+};
+
+// ============================================================================
+// Result Formatting
+// ============================================================================
+
+/**
+ * Format search results into a human-readable markdown string.
+ * Consistent with how other tools return content (read_file adds line numbers,
+ * grep formats matches with file paths).
+ */
+function formatSearchResults(results: SearchResult[], query: string): string {
+  if (results.length === 0) {
+    return `No results found for: "${query}"`;
+  }
+
+  const formatted = results.map((result, i) => {
+    const parts = [`## Result ${i + 1}: ${result.title}`, `URL: ${result.url}`];
+    if (result.content) {
+      parts.push('', result.content);
+    }
+    return parts.join('\n');
+  });
+
+  return `<web_search query="${escapeAttr(query)}" results="${results.length}">\n${formatted.join('\n\n---\n\n')}\n</web_search>`;
+}
+
+/** Escape characters that would break the XML-like output wrapper */
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// ============================================================================
+// Search Logic
+// ============================================================================
+
+/**
+ * Call the Ollama web search API.
+ */
+async function searchOllama(
+  query: string,
+  maxResults: number,
+  signal?: AbortSignal,
+): Promise<SearchResponse> {
+  const apiKey = process.env.OLLAMA_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'OLLAMA_API_KEY environment variable is required for web search',
+    );
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), SEARCH_TIMEOUT_MS);
+
+  const onExternalAbort = () => controller.abort();
+  if (signal) {
+    signal.addEventListener('abort', onExternalAbort, { once: true });
+  }
+
+  try {
+    const response = await fetch(OLLAMA_SEARCH_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        query,
+        max_results: maxResults,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(
+        `Ollama search API returned HTTP ${response.status}: ${response.statusText}${body ? ` — ${body}` : ''}`,
+      );
+    }
+
+    return (await response.json()) as SearchResponse;
+  } finally {
+    clearTimeout(timeoutId);
+    if (signal) {
+      signal.removeEventListener('abort', onExternalAbort);
+    }
+  }
+}
+
+// ============================================================================
+// Tool Definition
+// ============================================================================
+
+const currentYear = new Date().getFullYear();
+
+export const webSearchTool: ToolDefinition<
+  typeof inputSchema,
+  typeof outputSchema
+> = {
+  name: 'web_search',
+  description: `Search the web and return relevant results with titles, URLs, and content snippets.
+
+Use this tool for **discovery** — finding information you don't already have:
+- Documentation for unfamiliar APIs or libraries
+- Latest versions, changelogs, or migration guides
+- Error messages, Stack Overflow answers, or GitHub issues
+- Best practices and patterns for technologies you're adopting
+- Any information beyond your training data or that may have changed recently
+
+Do NOT use this tool when:
+- You already know the URL — use web_fetch instead to retrieve its content
+- The answer is in the local codebase — use grep, glob, or read_file instead
+- You already have sufficient information to answer the question
+
+The current year is ${currentYear}. Use this when formulating queries about recent information.
+
+After searching, you can use web_fetch to retrieve the full content of any promising result URL.
+
+Parameters:
+- query: The search query (required). Be specific — include library names, version numbers, or error messages.
+- max_results: Number of results to return (optional, default ${DEFAULT_MAX_RESULTS}, max ${MAX_RESULTS_LIMIT}).`,
+
+  parameters: inputSchema,
+  outputSchema,
+  risk: 'low',
+
+  execute: async (
+    params: { query: string; max_results?: number },
+    signal?: AbortSignal,
+  ) => {
+    const { query, max_results = DEFAULT_MAX_RESULTS } = params;
+
+    if (!query.trim()) {
+      return 'Error: Search query cannot be empty';
+    }
+
+    try {
+      const response = await searchOllama(query, max_results, signal);
+      return formatSearchResults(response.results ?? [], query);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return `Error: Search timed out after ${Math.round(SEARCH_TIMEOUT_MS / 1000)}s for query: "${query}"`;
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      return `Error searching for "${query}": ${message}`;
+    }
+  },
+};

--- a/src/tui/components/tool-message.tsx
+++ b/src/tui/components/tool-message.tsx
@@ -31,7 +31,14 @@ export type ToolMessageProps = {
 };
 
 /** Read-only tools that support expand/collapse */
-const EXPANDABLE_TOOLS = ['read_file', 'glob', 'grep', 'list_dir'];
+const EXPANDABLE_TOOLS = [
+  'read_file',
+  'glob',
+  'grep',
+  'list_dir',
+  'web_search',
+  'web_fetch',
+];
 
 /**
  * Format the tool header based on tool type and arguments.
@@ -67,6 +74,10 @@ function formatToolHeader(name: string, args: Record<string, unknown>): string {
       return String(args.path ?? '.');
     case 'task':
       return String(args.description ?? '');
+    case 'web_search':
+      return String(args.query ?? '');
+    case 'web_fetch':
+      return String(args.url ?? '');
     case 'todo_write': {
       const raw = args.todos;
       const todos = Array.isArray(raw)
@@ -196,6 +207,16 @@ function formatCompletedOutput(
       } catch {
         return output;
       }
+    }
+    case 'web_search': {
+      const lines = output.split('\n');
+      const resultCount = (output.match(/^## Result \d+:/gm) ?? []).length;
+      if (resultCount > 0) return `${resultCount} results`;
+      return `${lines.length} lines`;
+    }
+    case 'web_fetch': {
+      const lines = output.split('\n');
+      return `${lines.length} lines`;
     }
     case 'write_file':
     case 'edit_file':

--- a/tests/test-web-search.ts
+++ b/tests/test-web-search.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'bun:test';
+
+import { BUILTIN_EXPLORE_AGENT } from '../src/agent/agents/builtins';
+import {
+  PERMISSION_KEY_TO_TOOLS,
+  TOOL_TO_PERMISSION_KEY,
+} from '../src/agent/agents/schema';
+import { fromConfig, evaluate } from '../src/agent/permission/index';
+import {
+  getToolDefinition,
+  isToolAllowedByPermission,
+} from '../src/agent/tools/index';
+
+// ─── Tool definition ────────────────────────────────────────────────
+
+describe('web_search tool definition', () => {
+  it('is registered in the tool index', () => {
+    const tool = getToolDefinition('web_search');
+    expect(tool).toBeDefined();
+  });
+
+  it('has correct name', () => {
+    const tool = getToolDefinition('web_search');
+    expect(tool!.name).toBe('web_search');
+  });
+
+  it('has risk level "low"', () => {
+    const tool = getToolDefinition('web_search');
+    expect(tool!.risk).toBe('low');
+  });
+
+  it('has a description mentioning discovery', () => {
+    const tool = getToolDefinition('web_search');
+    expect(tool!.description).toContain('discovery');
+  });
+
+  it('has a description mentioning the current year', () => {
+    const tool = getToolDefinition('web_search');
+    const currentYear = new Date().getFullYear().toString();
+    expect(tool!.description).toContain(currentYear);
+  });
+
+  it('has required query parameter', () => {
+    const tool = getToolDefinition('web_search');
+    const result = tool!.parameters.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts valid parameters', () => {
+    const tool = getToolDefinition('web_search');
+    const result = tool!.parameters.safeParse({ query: 'test query' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts optional max_results', () => {
+    const tool = getToolDefinition('web_search');
+    const result = tool!.parameters.safeParse({
+      query: 'test query',
+      max_results: 3,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects max_results above 10', () => {
+    const tool = getToolDefinition('web_search');
+    const result = tool!.parameters.safeParse({
+      query: 'test query',
+      max_results: 11,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects max_results below 1', () => {
+    const tool = getToolDefinition('web_search');
+    const result = tool!.parameters.safeParse({
+      query: 'test query',
+      max_results: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── Permission system ──────────────────────────────────────────────
+
+describe('web_search permissions', () => {
+  it('has web_search key in PERMISSION_KEY_TO_TOOLS', () => {
+    expect(PERMISSION_KEY_TO_TOOLS.web_search).toBeDefined();
+    expect(PERMISSION_KEY_TO_TOOLS.web_search).toEqual(['web_search']);
+  });
+
+  it('has reverse mapping in TOOL_TO_PERMISSION_KEY', () => {
+    expect(TOOL_TO_PERMISSION_KEY.web_search).toBe('web_search');
+  });
+
+  it('explore agent has web_search: allow', () => {
+    expect(BUILTIN_EXPLORE_AGENT.permission.web_search).toBe('allow');
+  });
+
+  it('explore agent allows web_search tool', () => {
+    expect(
+      isToolAllowedByPermission('web_search', BUILTIN_EXPLORE_AGENT.permission),
+    ).toBe(true);
+  });
+
+  it('build agent allows web_search via wildcard', () => {
+    const buildPermission = { '*': 'allow' as const };
+    expect(isToolAllowedByPermission('web_search', buildPermission)).toBe(true);
+  });
+
+  it('plan agent allows web_search (no explicit deny)', () => {
+    const planPermission = { edit: 'deny' as const };
+    expect(isToolAllowedByPermission('web_search', planPermission)).toBe(true);
+  });
+
+  it('deny-all config blocks web_search', () => {
+    const denyAll = { '*': 'deny' as const };
+    expect(isToolAllowedByPermission('web_search', denyAll)).toBe(false);
+  });
+
+  it('user-defined agent can grant web_search', () => {
+    const customPermission = {
+      '*': 'deny' as const,
+      web_search: 'allow' as const,
+    };
+    expect(isToolAllowedByPermission('web_search', customPermission)).toBe(
+      true,
+    );
+  });
+});
+
+// ─── Result formatting (via execute) ────────────────────────────────
+
+describe('web_search execute', () => {
+  it('returns error for empty query', async () => {
+    const tool = getToolDefinition('web_search');
+    const result = await tool!.execute({ query: '   ', max_results: 5 });
+    expect(result).toContain('Error');
+    expect(result).toContain('empty');
+  });
+
+  it('returns error when OLLAMA_API_KEY is not set', async () => {
+    const originalKey = process.env.OLLAMA_API_KEY;
+    delete process.env.OLLAMA_API_KEY;
+
+    try {
+      const tool = getToolDefinition('web_search');
+      const result = await tool!.execute({
+        query: 'test query',
+        max_results: 5,
+      });
+      expect(result).toContain('Error');
+      expect(result).toContain('OLLAMA_API_KEY');
+    } finally {
+      if (originalKey) {
+        process.env.OLLAMA_API_KEY = originalKey;
+      }
+    }
+  });
+});

--- a/tests/test-web-search.ts
+++ b/tests/test-web-search.ts
@@ -5,7 +5,6 @@ import {
   PERMISSION_KEY_TO_TOOLS,
   TOOL_TO_PERMISSION_KEY,
 } from '../src/agent/agents/schema';
-import { fromConfig, evaluate } from '../src/agent/permission/index';
 import {
   getToolDefinition,
   isToolAllowedByPermission,
@@ -21,62 +20,62 @@ describe('web_search tool definition', () => {
 
   it('has correct name', () => {
     const tool = getToolDefinition('web_search');
-    expect(tool!.name).toBe('web_search');
+    expect(tool?.name).toBe('web_search');
   });
 
   it('has risk level "low"', () => {
     const tool = getToolDefinition('web_search');
-    expect(tool!.risk).toBe('low');
+    expect(tool?.risk).toBe('low');
   });
 
   it('has a description mentioning discovery', () => {
     const tool = getToolDefinition('web_search');
-    expect(tool!.description).toContain('discovery');
+    expect(tool?.description).toContain('discovery');
   });
 
   it('has a description mentioning the current year', () => {
     const tool = getToolDefinition('web_search');
     const currentYear = new Date().getFullYear().toString();
-    expect(tool!.description).toContain(currentYear);
+    expect(tool?.description).toContain(currentYear);
   });
 
   it('has required query parameter', () => {
     const tool = getToolDefinition('web_search');
-    const result = tool!.parameters.safeParse({});
-    expect(result.success).toBe(false);
+    const result = tool?.parameters.safeParse({});
+    expect(result?.success).toBe(false);
   });
 
   it('accepts valid parameters', () => {
     const tool = getToolDefinition('web_search');
-    const result = tool!.parameters.safeParse({ query: 'test query' });
-    expect(result.success).toBe(true);
+    const result = tool?.parameters.safeParse({ query: 'test query' });
+    expect(result?.success).toBe(true);
   });
 
   it('accepts optional max_results', () => {
     const tool = getToolDefinition('web_search');
-    const result = tool!.parameters.safeParse({
+    const result = tool?.parameters.safeParse({
       query: 'test query',
       max_results: 3,
     });
-    expect(result.success).toBe(true);
+    expect(result?.success).toBe(true);
   });
 
   it('rejects max_results above 10', () => {
     const tool = getToolDefinition('web_search');
-    const result = tool!.parameters.safeParse({
+    const result = tool?.parameters.safeParse({
       query: 'test query',
       max_results: 11,
     });
-    expect(result.success).toBe(false);
+    expect(result?.success).toBe(false);
   });
 
   it('rejects max_results below 1', () => {
     const tool = getToolDefinition('web_search');
-    const result = tool!.parameters.safeParse({
+    const result = tool?.parameters.safeParse({
       query: 'test query',
       max_results: 0,
     });
-    expect(result.success).toBe(false);
+    expect(result?.success).toBe(false);
   });
 });
 
@@ -93,16 +92,15 @@ describe('web_search permissions', () => {
   });
 
   it('explore agent has web_search: allow', () => {
-    expect(BUILTIN_EXPLORE_AGENT.permission!.web_search).toBe('allow');
+    expect(BUILTIN_EXPLORE_AGENT.permission?.web_search).toBe('allow');
   });
 
   it('explore agent allows web_search tool', () => {
-    expect(
-      isToolAllowedByPermission(
-        'web_search',
-        BUILTIN_EXPLORE_AGENT.permission!,
-      ),
-    ).toBe(true);
+    const permission = BUILTIN_EXPLORE_AGENT.permission;
+    expect(permission).toBeDefined();
+    expect(isToolAllowedByPermission('web_search', permission ?? {})).toBe(
+      true,
+    );
   });
 
   it('build agent allows web_search via wildcard', () => {
@@ -136,7 +134,7 @@ describe('web_search permissions', () => {
 describe('web_search execute', () => {
   it('returns error for empty query', async () => {
     const tool = getToolDefinition('web_search');
-    const result = await tool!.execute({ query: '   ', max_results: 5 });
+    const result = await tool?.execute({ query: '   ', max_results: 5 });
     expect(result).toContain('Error');
     expect(result).toContain('empty');
   });
@@ -147,7 +145,7 @@ describe('web_search execute', () => {
 
     try {
       const tool = getToolDefinition('web_search');
-      const result = await tool!.execute({
+      const result = await tool?.execute({
         query: 'test query',
         max_results: 5,
       });

--- a/tests/test-web-search.ts
+++ b/tests/test-web-search.ts
@@ -93,12 +93,15 @@ describe('web_search permissions', () => {
   });
 
   it('explore agent has web_search: allow', () => {
-    expect(BUILTIN_EXPLORE_AGENT.permission.web_search).toBe('allow');
+    expect(BUILTIN_EXPLORE_AGENT.permission!.web_search).toBe('allow');
   });
 
   it('explore agent allows web_search tool', () => {
     expect(
-      isToolAllowedByPermission('web_search', BUILTIN_EXPLORE_AGENT.permission),
+      isToolAllowedByPermission(
+        'web_search',
+        BUILTIN_EXPLORE_AGENT.permission!,
+      ),
     ).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Adds a `web_search` tool that queries the Ollama web search API for discovery of web content. Complements the existing `web_fetch` tool (which retrieves known URLs) by enabling agents to search for information they don't already have.

## Changes

**Core tool** (`src/agent/tools/web-search.ts`):
- Calls Ollama `POST /api/web_search` with `query` and `max_results` (1-10, default 5)
- Returns markdown-formatted results with titles, URLs, and content snippets
- 25s timeout, graceful error handling for network/API failures
- Tool description includes current year injection and guidance on when to search vs fetch

**Permission wiring**:
- `web_search` permission key added to `PERMISSION_KEY_TO_TOOLS` in `schema.ts`
- Explore agent gets explicit `web_search: allow` in `builtins.ts`
- Build agent inherits via wildcard, plan agent inherits via no-deny default
- User-defined agents can grant access with `web_search: allow` in frontmatter

**TUI** (`tool-message.tsx`):
- `web_search` and `web_fetch` added to `EXPANDABLE_TOOLS` (ctrl+e to expand)
- `web_search` header shows the query; output summary shows result count
- `web_fetch` header shows the URL; output summary shows line count

**Tests** (`tests/test-web-search.ts`):
- 20 tests covering tool definition shape, parameter validation, permission key registration, all built-in agent access patterns, and error handling

## Closes #134